### PR TITLE
Implement Libcanard Library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,6 @@
+CC = gcc
+
+all: 
+	$(CC) -g -Wall canard_test.c canard.c -lpthread -std=gnu99 -o canard
+clean:
+	-rm $(objects) canard

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 CC = gcc
-
+CPP = g++
 all: 
 	$(CC) -g -Wall canard_test.c canard.c -lpthread -std=gnu99 -o canard
+crc_test:
+	$(CC) -g -Wall crc_test.c -lpthread -std=gnu99 -o crc_test
 clean:
-	-rm $(objects) canard
+	-rm $(objects) crc_test canard

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CPP = g++
 all: 
-	$(CC) -g -Wall canard_test.c canard.c -lpthread -std=gnu99 -o canard
+	$(CC) -g -Wall canard_test.c canard.c -m32 -lpthread -std=gnu99 -o canard
 crc_test:
 	$(CC) -g -Wall crc_test.c -lpthread -std=gnu99 -o crc_test
 clean:

--- a/src/canard.c
+++ b/src/canard.c
@@ -101,6 +101,9 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
     } else 
     {
       //anonymous transfer, random discriminator
+      uint16_t discriminator = (crc_add(0xFFFFU, payload, payload_len)) & 0x7FFEU;
+      can_id = ((uint32_t)priority << 24) | (uint32_t)(discriminator << 9) |
+        ((uint32_t)(data_type_id & 0xFF) << 8) | (uint32_t)canardGetLocalNodeID(ins);
     }
   }
   } else

--- a/src/canard.c
+++ b/src/canard.c
@@ -311,6 +311,9 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
     if (rxstate->calculated_crc == rxstate->payload_crc)
     {
       ins->on_reception(ins,&rxtransfer);
+    } else
+    {
+      canardReleaseRxTransferPayload(ins, &rxtransfer);
     }
     canardPrepareForNextTransfer(rxstate);
     return;

--- a/src/canard.c
+++ b/src/canard.c
@@ -272,12 +272,12 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
 
   if (TOGGLE_BIT(tail_byte) != rxstate->next_toggle)
   {
-    return;
+    return;  //wrong toggle
   }
 
   if (TRANSFER_ID_FROM_TAIL_BYTE(tail_byte) != rxstate->transfer_id)
   {
-    return;
+    return;  //unexpected tid
   }
 
   if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
@@ -458,6 +458,7 @@ CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint
 
       if (data_index == 0)
       {
+        //add crc
         queue_item->frame.data[0] = (uint8_t)(crc >> 8);
         queue_item->frame.data[1] = (uint8_t)(crc);
         i = 2;
@@ -469,7 +470,7 @@ CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint
       {
         queue_item->frame.data[i] = payload[data_index];
       }
-
+      //tail byte
       sot_eot = (data_index==payload_len) ? 0x40 : sot_eot;
 
       queue_item->frame.data[i] = sot_eot | (toggle << 5) | (*transfer_id & 31);
@@ -498,7 +499,7 @@ CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* i
   CanardTxQueueItem* previous = ins->tx_queue;
   while (queue != NULL)
   {
-    if (priorityHigherThan(queue->frame.id, item->frame.id))
+    if (priorityHigherThan(queue->frame.id, item->frame.id)) //lower number wins
     {
       if (queue == ins->tx_queue)
       {
@@ -736,6 +737,7 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
   CanardBufferBlock* block;
   uint8_t nth_block = 1;
   
+  //buffer blocks uninitialized
   if (state->buffer_blocks == NULL)
   {
     state->buffer_blocks = canardCreateBufferBlock(allocator);
@@ -744,6 +746,7 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
   }
   else
   {
+    //get to block
     block = state->buffer_blocks;
     while (block->next != NULL)
     {

--- a/src/canard.c
+++ b/src/canard.c
@@ -1,5 +1,25 @@
 /*
- * Copyright (C) 2015 Michael Sierra <sierramichael.a@gmail.com>
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 UAVCAN Team
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. 
  */
 
 #include "canard.h"

--- a/src/canard.c
+++ b/src/canard.c
@@ -259,7 +259,6 @@ CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* i
       }
     }
   }
-  //canardPrintQueue(ins);
 }
 
 /**
@@ -362,14 +361,8 @@ CANARD_INTERNAL uint8_t canardTransferType(uint32_t id) {
 CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor) {
   CanardRxState* states = ins->rx_states;
 
-  //printf("%p  %p\n", states, ins->rx_states);
-  // printf("\nlooking for: %" PRIu32 "\n", transfer_descriptor);
-
   if (states==NULL) {           //initialize CanardRxStates
-    // printf("its null\n");
     states = canardCreateRxState(&ins->allocator, transfer_descriptor);
-    // printf("states [0]: %p ", states);
-    // printf("%" PRIu32 "\n", states->dtid_tt_snid_dnid);
     ins->rx_states = states;
     return states;
   }
@@ -402,7 +395,6 @@ CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t
   CanardRxState* states = ins->rx_states;
   static int i = 1;
   if(states->next == NULL) {
-    // printf("appended first state\n");
     states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
     return states->next;
   }
@@ -411,7 +403,6 @@ CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t
     states = states->next;
   }
   i++;
-  // printf("appended %ith state", i);
   states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
   return states->next;
 }

--- a/src/canard.c
+++ b/src/canard.c
@@ -242,6 +242,8 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
     .priority = priority,
     .source_node_id = source_node_id };
 
+    //crc validation goes here!
+
     ins->on_reception(ins,&rxtransfer);
 
     canardPrepareForNextTransfer(rxstate);

--- a/src/canard.c
+++ b/src/canard.c
@@ -356,6 +356,73 @@ void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec
     prev = state;
     state = state->next;
   }
+/**
+ * Reads bits (1 to 64) from RX transfer buffer.
+ * This function can be used to decode received transfers.
+ * Note that this function does not need the library's instance object.
+ */
+uint64_t canardReadRxTransferPayload(const CanardRxTransfer* transfer,
+                                     uint16_t bit_offset,
+                                     uint8_t bit_length)
+{
+    uint64_t bits = 0;
+    int shift_val =  bit_length - 8;
+    if (transfer->payload_len > 7)      //multi frame
+    {
+        CanardBufferBlock* block = transfer->payload_middle;
+        int i;
+        uint8_t index = 0;
+
+        if (CANARD_RX_PAYLOAD_HEAD_SIZE > 0)    //head
+        {
+            for (i = 0; i<CANARD_RX_PAYLOAD_HEAD_SIZE && index<bit_length && shift_val>=0; i++, index++)
+            {
+                if (index>=bit_offset / 8)
+                {
+                    bits |= ((uint64_t)transfer->payload_head[i] << shift_val);
+                    shift_val -= 8;
+                }
+            }
+        }
+        //middle (buffer blocks)
+        for (i = 0; index<(CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len) &&
+             index<bit_length && shift_val>=0; i++, index++)
+        {
+            if (index>=bit_offset / 8)
+            {
+                bits |= ((uint64_t)block->data[i] << shift_val);
+                shift_val -= 8;
+            }
+            if (i==CANARD_BUFFER_BLOCK_DATA_SIZE - 1)
+            {
+                i = 0;
+                block = block->next;
+            }
+        }
+        // tail
+        int tail_len = transfer->payload_len - (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len);
+        for (i = 0; i<(tail_len) && index<bit_length && shift_val>=0; i++, index++)
+        {
+            if (index>=bit_offset / 8)
+            {
+                bits |= ((uint64_t)transfer->payload_tail[i] << shift_val);
+                shift_val -= 8;
+            }
+        }
+    }
+    else    //single frame
+    {
+        uint8_t i;
+        for (i = 0; i<transfer->payload_len && i<bit_length && shift_val>=0; i++)
+        {
+            if (i>=bit_offset / 8)
+            {
+                bits |= ((uint64_t)transfer->payload_head[i] << shift_val);
+                shift_val -= 8;
+            }
+        }
+    }
+    return bits;
 }
 
 /**

--- a/src/canard.c
+++ b/src/canard.c
@@ -85,6 +85,15 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
   {
       return -1;
   }
+  if (canardGetLocalNodeID(ins) == 0)
+  { 
+    if (payload_len > 7)
+    {
+      return -1;
+    } else 
+    {
+      //anonymous transfer, random discriminator
+    }
   if (canardGetLocalNodeID(ins) == 0 && payload_len > 7)
   {
     return -1;

--- a/src/canard.c
+++ b/src/canard.c
@@ -364,16 +364,14 @@ uint64_t canardReadRxTransferPayload(const CanardRxTransfer* transfer,
         CanardBufferBlock* block = transfer->payload_middle;
         int i;
         uint8_t index = 0;
-
-        if (CANARD_RX_PAYLOAD_HEAD_SIZE > 0)    //head
+        
+        //head
+        for (i = 0; i<CANARD_RX_PAYLOAD_HEAD_SIZE && index<bit_length && shift_val>=0; i++, index++)
         {
-            for (i = 0; i<CANARD_RX_PAYLOAD_HEAD_SIZE && index<bit_length && shift_val>=0; i++, index++)
+            if (index>=bit_offset / 8)
             {
-                if (index>=bit_offset / 8)
-                {
-                    bits |= ((uint64_t)transfer->payload_head[i] << shift_val);
-                    shift_val -= 8;
-                }
+                bits |= ((uint64_t)transfer->payload_head[i] << shift_val);
+                shift_val -= 8;
             }
         }
         //middle (buffer blocks)

--- a/src/canard.c
+++ b/src/canard.c
@@ -497,6 +497,9 @@ CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* i
 CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator)
 {
   CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
+  if (item == NULL) {
+    return NULL;
+  }
   memset(item, 0, sizeof *item);
 
   return item;
@@ -657,6 +660,9 @@ CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocato
   CanardRxState init = {.next = NULL, .buffer_blocks = NULL, .dtid_tt_snid_dnid = transfer_descriptor};
   CanardRxState* state = (CanardRxState *)canardAllocateBlock(allocator);
 
+  if (state == NULL) {
+    return NULL;
+  }
   memcpy(state, &init, sizeof *state);
 
   return state;
@@ -739,6 +745,9 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
 CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator)
 {
   CanardBufferBlock* block = (CanardBufferBlock *)canardAllocateBlock(allocator);
+  if (block == NULL) {
+    return NULL;
+  }
   block->next = NULL;
   return block;
 }

--- a/src/canard.c
+++ b/src/canard.c
@@ -221,10 +221,12 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
   } else if (!IS_START_OF_TRANSFER(tail_byte))
   {
     rxstate = canardFindRxState(ins->rx_states, transfer_descriptor);
-    if (rxstate == NULL) {
-      return;
-    }
   }
+
+  if (rxstate == NULL) {
+    return;
+  }
+
 
   // Resolving the state flags:
   const bool not_initialized = (rxstate->timestamp_usec == 0) ? true : false;

--- a/src/canard.c
+++ b/src/canard.c
@@ -44,14 +44,15 @@ struct CanardTxQueueItem
  * Initializes the library state.
  * Local node ID will be set to zero, i.e. the node will be anonymous.
  */
-void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept)
+void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size,
+                  canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept)
 {
   out_ins->node_id = CANARD_BROADCAST_NODE_ID;
   out_ins->on_reception = on_reception;
   out_ins->should_accept = should_accept;
   out_ins->rx_states = NULL;
   out_ins->tx_queue = NULL;
-  canardInitPoolAllocator(&out_ins->allocator, out_ins->buffer, CANARD_AVAILABLE_BLOCKS);
+  canardInitPoolAllocator(&out_ins->allocator, mem_arena, mem_arena_size/CANARD_MEM_BLOCK_SIZE);
 }
 
 /**

--- a/src/canard.c
+++ b/src/canard.c
@@ -635,6 +635,17 @@ CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t
   states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
   return states->next;
 }
+*/
+/**
+ * prepends rx state to the canard instance rx_states
+ */
+CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor)
+{
+  CanardRxState* state = canardCreateRxState(&ins->allocator, transfer_descriptor);
+  state->next = ins->rx_states;
+  ins->rx_states = state;
+  return state;
+}
 
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor)
 {

--- a/src/canard.c
+++ b/src/canard.c
@@ -467,10 +467,8 @@ CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* i
  */
 CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator)
 {
-  CanardTxQueueItem init = {0};
   CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
-
-  memcpy(item, &init, sizeof *item);
+  memset(item, 0, sizeof *item);
 
   return item;
 }

--- a/src/canard.c
+++ b/src/canard.c
@@ -92,7 +92,7 @@ int canardBroadcast(CanardInstance* ins,
         {
             // anonymous transfer, random discriminator
             uint16_t discriminator = (crcAdd(0xFFFFU, payload, payload_len)) & 0x7FFEU;
-            can_id = ((uint32_t)priority << 24) | (uint32_t)(discriminator << 9) |
+            can_id = ((uint32_t)priority << 24) | ((uint32_t)discriminator << 9) |
                      ((uint32_t)(data_type_id & 0xFF) << 8) | (uint32_t)canardGetLocalNodeID(ins);
         }
     }

--- a/src/canard.c
+++ b/src/canard.c
@@ -158,7 +158,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
   
   CanardRxState* rxstate;
   unsigned char tail_byte = frame->data[frame->data_len-1];
-  rxstate = canardRxStateTraversal(ins, frame, transfer_descriptor);
+  rxstate = canardRxStateTraversal(ins, transfer_descriptor);
 
   // // Resolving the state flags:
   const bool not_initialized = (rxstate->timestamp_usec == 0) ? true : false;
@@ -576,7 +576,7 @@ CANARD_INTERNAL uint8_t canardTransferType(uint32_t id)
  * Traverses the list of CanardRxState's and returns a pointer to the CanardRxState 
  * with either the Id or a new one at the end
  */
-CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor)
+CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor)
 {
   CanardRxState* states = ins->rx_states;
 

--- a/src/canard.c
+++ b/src/canard.c
@@ -1,5 +1,501 @@
 #include "canard.h"
 #include "canard_internals.h"
+// #include <inttypes.h>
+
+
+#define CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id, transfer_type, \
+                                        src_node_id, dst_node_id) \
+    ((data_type_id) | ((transfer_type) << 16) | \
+     ((src_node_id) << 18) | ((dst_node_id) << 25))
+
+struct CanardTxQueueItem
+{
+  CanardTxQueueItem* next;
+  CanardCANFrame frame;
+};
+
+/**
+ *  API functions
+ */
+
+/**
+ * Initializes the library state.
+ * Local node ID will be set to zero, i.e. the node will be anonymous.
+ */
+void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception) {
+  out_ins->node_id = CANARD_BROADCAST_NODE_ID;
+  out_ins->on_reception = on_reception;
+  out_ins->rx_states = NULL;
+  out_ins->tx_queue = NULL;
+  canardInitPoolAllocator(&out_ins->allocator, out_ins->buffer, CANARD_AVAILABLE_BLOCKS);
+}
+
+/**
+ * Assigns a new node ID value to the current node.
+ */
+void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id) {
+  ins->node_id = self_node_id;
+}
+
+/**
+ * Returns node ID of the local node.
+ * Returns zero if the node ID has not been set.
+ */
+uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
+  return ins->node_id;
+}
+
+/**
+ * Sends a broadcast transfer.
+ * If the node is in passive mode, only single frame transfers will be allowed.
+ */
+ int canardBroadcast(CanardInstance* ins,
+                      uint16_t data_type_id,
+                      uint8_t* inout_transfer_id,
+                      uint8_t priority,
+                      const uint8_t* payload,
+                      uint16_t payload_len) {
+  if (payload == NULL)
+  {
+      return -1;
+  }
+  if (canardGetLocalNodeID(ins) == 0 && payload_len > 7) {
+    return -1;
+  }
+  if (priority > 31)
+  {
+      return -1;
+  }
+
+  const uint32_t can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 8) | (uint32_t)canardGetLocalNodeID(ins);
+  //single frame transfer
+  if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN) {  
+
+    CanardTxQueueItem* queue_item = canardCreateTxItem(&ins->allocator);
+
+    memcpy(queue_item->frame.data, payload, payload_len);
+
+    queue_item->frame.data_len = payload_len+1;
+
+    queue_item->frame.data[payload_len] = 0xC0 | (*inout_transfer_id & 31);
+
+    queue_item->frame.id = can_id;
+
+    *inout_transfer_id += 1;
+    if (*inout_transfer_id >= 32) {
+      *inout_transfer_id = 0;
+    }
+
+    canardPushTxQueue(ins, queue_item);
+
+  } else if (payload_len >= CANARD_CAN_FRAME_MAX_DATA_LEN){
+    //multiframe transfer
+    uint8_t i=2, data_index = 0, toggle = 0, sot_eot = 0x80;
+
+    CanardTxQueueItem* frame;
+
+    while (payload_len - data_index != 0) {
+      frame = canardCreateTxItem(&ins->allocator);
+
+      if (data_index == 0) {
+        frame->frame.data[0] = 0xFF;
+        frame->frame.data[1] = 0XFF;
+        i = 2;
+      } else {
+        i = 0;
+      }
+
+      for (; i<7 && data_index<payload_len; i++, data_index++) {
+        frame->frame.data[i] = payload[data_index];
+      }
+
+      sot_eot = (data_index==payload_len) ? 0x40: sot_eot;
+
+      *inout_transfer_id += 1;
+      if (*inout_transfer_id >= 32) {
+        *inout_transfer_id = 0;
+      }
+
+      frame->frame.data[i] = sot_eot | (toggle << 5) | (*inout_transfer_id & 31);
+      frame->frame.id = can_id;
+      frame->frame.data_len = i+1;
+      canardPushTxQueue(ins,frame);
+
+      toggle ^= 1;
+      sot_eot = 0;
+    }
+  }
+  return 1;
+}
+
+/**
+ * Returns a pointer to the top priority frame in the TX queue.
+ * Returns NULL if the TX queue is empty.
+ */
+const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins) {
+  if (ins->tx_queue == NULL) {
+    return NULL;
+  }
+  return &ins->tx_queue->frame;
+}
+
+/**
+ * Removes the top priority frame from the TX queue.
+ */
+void canardPopTxQueue(CanardInstance* ins) {
+  CanardTxQueueItem* item = ins->tx_queue;
+  ins->tx_queue = item->next;
+  canardFreeBlock(&ins->allocator, item);
+}
+
+/**
+ * Processes a received CAN frame with a timestamp.
+ */
+void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec) {
+  
+  uint8_t transfer_type = canardTransferType(frame->id);
+  uint8_t priority = CANARD_PRIORITY_FROM_ID(frame->id);
+  uint8_t source_node_id = CANARD_SOURCE_ID_FROM_ID(frame->id);
+  uint8_t destination_node_id = (transfer_type == CanardTransferTypeBroadcast) ? 0 : CANARD_DEST_ID_FROM_ID(frame->id);
+  uint16_t data_type_id = canardDataType(frame->id);
+  uint32_t transfer_descriptor = CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id,transfer_type,source_node_id,destination_node_id);
+  
+  CanardRxState* rxstate;
+  unsigned char tail_byte = frame->data[frame->data_len-1];
+  rxstate = canardRxStateTraversal(ins, frame, transfer_descriptor);
+
+  if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte)) {  // single frame transfer
+
+    rxstate->timestamp_usec = timestamp_usec;
+    CanardRxTransfer rxtransfer = {
+    .payload_head = frame->data,
+    .payload_len = frame->data_len-1,
+    .data_type_id = data_type_id,
+    .transfer_type = transfer_type,
+    .priority = priority,
+    .source_node_id = source_node_id };
+    ins->on_reception(ins,&rxtransfer);
+
+  } else if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte)) {  // beginning of multi frame transfer
+    //take off the crc and store the payload
+    rxstate->timestamp_usec = timestamp_usec;
+
+    canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data+2, frame->data_len-3);
+
+  } else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte)) {
+
+    canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data, frame->data_len-1);
+
+  } else { 
+    CanardRxTransfer rxtransfer = {
+    .timestamp_usec = timestamp_usec,
+    .payload_head = rxstate->buffer_head,
+    .payload_middle = rxstate->buffer_blocks,
+    .payload_tail = frame->data,
+    .payload_len = rxstate->payload_len+frame->data_len-1,
+    .data_type_id = data_type_id,
+    .transfer_type = transfer_type,
+    .priority = priority,
+    .source_node_id = source_node_id };
+
+    cleanCanardRxState(rxstate);
+
+    ins->on_reception(ins,&rxtransfer);
+  }
+}
+
+
+/**
+ * This function can be invoked by the application to release pool blocks that are used
+ * to store the payload of this transfer
+ */
+uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer) {
+  CanardBufferBlock *block, *temp = transfer->payload_middle;
+  while (block != NULL) {
+    block = temp;
+    temp = block->next;
+    canardFreeBlock(&ins->allocator, block);
+  }
+  transfer->payload_middle = NULL;
+  transfer->payload_head = NULL;
+  transfer->payload_tail = NULL;
+  transfer->payload_len = 0;
+  return 0;
+}
+
+/**
+ *  internal (static functions)
+ *
+ *
+ */
+
+/**
+ * Puts frame on on the TX queue. Higher priority placed first
+ */
+CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item) {
+  if (ins->tx_queue == NULL) {
+    ins->tx_queue = item;
+    return;
+  }
+  CanardTxQueueItem* queue = ins->tx_queue;
+  CanardTxQueueItem* previous = ins->tx_queue;
+  while (queue != NULL) {
+    if (priorityHigherThan(queue->frame.id, item->frame.id)) {
+      if (queue == ins->tx_queue) {
+        item->next = queue;
+        ins->tx_queue = item;
+      } else {
+        previous->next = item;
+        item->next = queue;
+      }
+      return;
+    } else {
+      if (queue->next == NULL) {
+        queue->next = item;
+        return;
+      } else {
+        previous = queue;
+        queue = queue->next;
+      }
+    }
+  }
+  //canardPrintQueue(ins);
+}
+
+/**
+ * creates new tx queue item from allocator
+ */
+CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator) {
+  CanardTxQueueItem init = {0};
+  CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
+
+  memcpy(item, &init, sizeof *item);
+
+  return item;
+}
+
+/**
+ * returns true if priority of rhs is higher than id
+ */
+CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id) {
+  const uint32_t clean_id     = id    & CANARD_EXT_ID_MASK;
+  const uint32_t rhs_clean_id = rhs   & CANARD_EXT_ID_MASK;
+  /*
+   * STD vs EXT - if 11 most significant bits are the same, EXT loses.
+   */
+  bool ext     = id     & CANARD_CAN_FRAME_EFF;
+  bool rhs_ext = rhs & CANARD_CAN_FRAME_EFF;
+  if (ext != rhs_ext)
+  {
+    uint32_t arb11     = ext     ? (clean_id >> 18)     : clean_id;
+    uint32_t rhs_arb11 = rhs_ext ? (rhs_clean_id >> 18) : rhs_clean_id;
+    if (arb11 != rhs_arb11)
+    {
+        return arb11 < rhs_arb11;
+    }
+    else
+    {
+        return rhs_ext;
+    }
+  }
+
+  /*
+   * RTR vs Data frame - if frame identifiers and frame types are the same, RTR loses.
+   */
+  bool rtr     = id     & CANARD_CAN_FRAME_RTR;
+  bool rhs_rtr = rhs & CANARD_CAN_FRAME_RTR;
+  if (clean_id == rhs_clean_id && rtr != rhs_rtr)
+  {
+    return rhs_rtr;
+  }
+
+  /*
+   * Plain ID arbitration - greater value loses.
+   */
+  return clean_id < rhs_clean_id;
+}
+
+/**
+ * preps the rx state for the next transfer. does not delete the state
+ */
+CANARD_INTERNAL void cleanCanardRxState(CanardRxState* state) {
+  state->buffer_blocks = NULL;
+  state->payload_len = 0;
+  state->transfer_id = 0;
+  state->next_toggle = 0;
+}
+
+/**
+ * returns data type from id
+ */
+CANARD_INTERNAL uint16_t canardDataType(uint32_t id) {
+  uint8_t transfer_type = canardTransferType(id);
+  if (transfer_type == CanardTransferTypeBroadcast) {
+    return (uint16_t)CANARD_MSG_TYPE_FROM_ID(id);
+  } else {
+    return (uint16_t)CANARD_SRV_TYPE_FROM_ID(id);
+  }
+}
+
+/**
+ * returns transfer type from id
+ */
+CANARD_INTERNAL uint8_t canardTransferType(uint32_t id) {
+  uint8_t is_service= (uint8_t)CANARD_SERVICE_NOT_MSG_FROM_ID(id);
+  if (is_service == 0) {
+    return CanardTransferTypeBroadcast;
+  } else if (CANARD_REQUEST_NOT_RESPONSE_FROM_ID(id) == 1) {
+    return CanardTransferTypeRequest;
+  } else {
+    return CanardTransferTypeResponse;
+  }
+}
+
+/**
+ *  CanardRxState functions
+ */
+
+/**
+ * Traverses the list of CanardRxState's and returns a pointer to the CanardRxState 
+ * with either the Id or a new one at the end
+ */
+CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor) {
+  CanardRxState* states = ins->rx_states;
+
+  //printf("%p  %p\n", states, ins->rx_states);
+  // printf("\nlooking for: %" PRIu32 "\n", transfer_descriptor);
+
+  if (states==NULL) {           //initialize CanardRxStates
+    // printf("its null\n");
+    states = canardCreateRxState(&ins->allocator, transfer_descriptor);
+    // printf("states [0]: %p ", states);
+    // printf("%" PRIu32 "\n", states->dtid_tt_snid_dnid);
+    ins->rx_states = states;
+    return states;
+  }
+
+  states = canardFindRxState(states, transfer_descriptor);
+  if (states != NULL) {
+    return states;
+  } else {
+    return canardAppendRxState(ins, transfer_descriptor);
+  }
+}
+
+/**
+ * returns pointer to the rx state of transfer descriptor or null if not found
+ */
+CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor) {
+  while(state != NULL) {
+    if(state->dtid_tt_snid_dnid == transfer_descriptor) {
+      return state;
+    }
+    state = state->next;
+  }
+  return NULL;
+}
+
+/**
+ * appends rx state to the canard instance rx_states
+ */
+CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor) {
+  CanardRxState* states = ins->rx_states;
+  static int i = 1;
+  if(states->next == NULL) {
+    // printf("appended first state\n");
+    states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
+    return states->next;
+  }
+
+  while(states->next != NULL) {
+    states = states->next;
+  }
+  i++;
+  // printf("appended %ith state", i);
+  states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
+  return states->next;
+}
+
+CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor) {
+  CanardRxState init = {.next = NULL, .buffer_blocks = NULL, .dtid_tt_snid_dnid = transfer_descriptor};
+  CanardRxState* state = (CanardRxState *)canardAllocateBlock(allocator);
+
+  memcpy(state, &init, sizeof *state);
+
+  return state;
+}
+
+/**
+ *  CanardBufferBlock functions
+ */
+
+ /**
+ * pushes data into the rx state. Fills the buffer head, then appends data to buffer blocks
+ */
+CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len) {
+  uint8_t data_index = 0;
+  uint8_t i;
+
+  // if head is not full, add data to head
+  if (CANARD_RX_PAYLOAD_HEAD_SIZE - state->payload_len > 0) {
+    for (i=state->payload_len; i<CANARD_RX_PAYLOAD_HEAD_SIZE && data_index<data_len; i++, data_index++) {
+      state->buffer_head[i] = data[data_index];
+    }
+    if (data_index >= data_len-1) {
+      state->payload_len += data_len;
+      return;
+    }
+  } //head is full.
+
+  uint8_t num_buffer_blocks = (((state->payload_len + data_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) / CANARD_BUFFER_BLOCK_DATA_SIZE)+1;
+  uint8_t index_at_nth_block = ((state->payload_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) % CANARD_BUFFER_BLOCK_DATA_SIZE;
+    
+  //get to current block
+  CanardBufferBlock* block;
+  uint8_t nth_block = 1;
+  if (state->buffer_blocks == NULL) {
+    state->buffer_blocks = canardCreateBufferBlock(allocator);
+    block = state->buffer_blocks;
+  } else {
+    block = state->buffer_blocks;
+    while (block->next != NULL) {
+      nth_block++;
+      block = block->next;
+    }
+    if (num_buffer_blocks > nth_block && index_at_nth_block == 0) {
+      block->next = canardCreateBufferBlock(allocator);
+      block = block->next;
+      nth_block++;
+    }
+  }
+
+  // add data to current block until it becomes full, add new block if necessary
+  while (data_index < data_len) {
+    for (i=index_at_nth_block; i<CANARD_BUFFER_BLOCK_DATA_SIZE && data_index<data_len; i++, data_index++) {
+      block->data[i] = data[data_index];
+    }
+    if (data_index < data_len) {
+      block->next = canardCreateBufferBlock(allocator);
+      block = block->next;
+      index_at_nth_block = 0;
+    }
+  }
+  state->payload_len += data_len;
+  return;
+}
+
+/**
+ * creates new buffer block
+ */
+CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator) {
+  CanardBufferBlock* block = (CanardBufferBlock *)canardAllocateBlock(allocator);
+  block->next = NULL;
+  return block;
+}
+
+/**
+ *  Pool Allocator functions
+ */
 
 CANARD_INTERNAL void canardInitPoolAllocator(CanardPoolAllocator* allocator, CanardPoolAllocatorBlock* buf, unsigned int buf_len)
 {

--- a/src/canard.c
+++ b/src/canard.c
@@ -750,6 +750,36 @@ CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* 
 }
 
 /**
+ * CRC functions
+ */
+CANARD_INTERNAL uint16_t crc_add_byte(uint16_t crc_val, uint8_t byte)
+{
+    crc_val ^= (uint16_t)((uint16_t)(byte) << 8);
+    int j;
+    for (j=0; j<8; j++)
+    {
+        if (crc_val & 0x8000U)
+        {
+            crc_val = (uint16_t)((uint16_t)(crc_val << 1) ^ 0x1021U);
+        }
+        else
+        {
+            crc_val = (uint16_t)(crc_val << 1);
+        }
+    }
+    return crc_val;
+}
+
+CANARD_INTERNAL uint16_t crc_add(uint16_t crc_val, const uint8_t* bytes, uint16_t len)
+{
+    while (len--)
+    {
+        crc_val = crc_add_byte(crc_val,*bytes++);
+    }
+    return crc_val;
+}
+
+/**
  *  Pool Allocator functions
  */
 

--- a/src/canard.c
+++ b/src/canard.c
@@ -439,23 +439,6 @@ uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* t
 }
 
 /**
- * This function can be invoked by the application to release pool blocks that are used
- * to store the payload of this transfer
- */
-CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate)
-{
-    CanardBufferBlock* temp = rxstate->buffer_blocks;
-    while (rxstate->buffer_blocks != NULL)
-    {
-        temp = rxstate->buffer_blocks->next;
-        canardFreeBlock(&ins->allocator, rxstate->buffer_blocks);
-        rxstate->buffer_blocks = temp;
-    }
-    rxstate->payload_len = 0;
-    return 0;
-}
-
-/**
  *  internal (static functions)
  *
  *
@@ -775,6 +758,23 @@ CANARD_INTERNAL CanardRxState* canardCreateRxState(CanardPoolAllocator* allocato
     memcpy(state, &init, sizeof *state);
 
     return state;
+}
+
+/**
+ * This function can be invoked by the application to release pool blocks that are used
+ * to store the payload of this transfer
+ */
+CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate)
+{
+    CanardBufferBlock* temp = rxstate->buffer_blocks;
+    while (rxstate->buffer_blocks != NULL)
+    {
+        temp = rxstate->buffer_blocks->next;
+        canardFreeBlock(&ins->allocator, rxstate->buffer_blocks);
+        rxstate->buffer_blocks = temp;
+    }
+    rxstate->payload_len = 0;
+    return 0;
 }
 
 /**

--- a/src/canard.c
+++ b/src/canard.c
@@ -592,7 +592,7 @@ CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint3
   }
   else
   {
-    return canardAppendRxState(ins, transfer_descriptor);
+    return canardPrependRxState(ins, transfer_descriptor);
   }
 }
 
@@ -615,10 +615,9 @@ CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t 
 /**
  * appends rx state to the canard instance rx_states
  */
-CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor)
+/*CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor)
 {
   CanardRxState* states = ins->rx_states;
-  static int i = 1;
   if(states->next == NULL)
   {
     states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
@@ -629,7 +628,6 @@ CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t
   {
     states = states->next;
   }
-  i++;
   states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
   return states->next;
 }

--- a/src/canard.c
+++ b/src/canard.c
@@ -613,26 +613,6 @@ CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t 
 }
 
 /**
- * appends rx state to the canard instance rx_states
- */
-/*CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor)
-{
-  CanardRxState* states = ins->rx_states;
-  if(states->next == NULL)
-  {
-    states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
-    return states->next;
-  }
-
-  while(states->next != NULL)
-  {
-    states = states->next;
-  }
-  states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
-  return states->next;
-}
-*/
-/**
  * prepends rx state to the canard instance rx_states
  */
 CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor)

--- a/src/canard.c
+++ b/src/canard.c
@@ -238,10 +238,6 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         if (!IS_START_OF_TRANSFER(tail_byte)) // missed the first frame
         {
             rxstate->transfer_id += 1;
-            if (rxstate->transfer_id >= 32)
-            {
-                rxstate->transfer_id = 0;
-            }
             return;
         }
     }
@@ -650,10 +646,6 @@ CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state)
 {
     state->buffer_blocks = NULL; // payload should be empty anyway
     state->transfer_id += 1;
-    if (state->transfer_id >= 32)
-    {
-        state->transfer_id = 0;
-    }
     state->payload_len = 0;
     state->next_toggle = 0;
     return;

--- a/src/canard.c
+++ b/src/canard.c
@@ -1,29 +1,16 @@
 /*
- * The MIT License (MIT)
- * 
  * Copyright (c) 2016 UAVCAN Team
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ *
+ * Distributed under the MIT License, available in the file LICENSE.
+ *
+ * Author: Michael Sierra <sierramichael.a@gmail.com>
+ *
  */
 
 #include "canard.h"
 #include "canard_internals.h"
+#include <inttypes.h>
+
 
 #define CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id, transfer_type, \
                                         src_node_id, dst_node_id) \
@@ -32,8 +19,8 @@
 
 struct CanardTxQueueItem
 {
-  CanardTxQueueItem* next;
-  CanardCANFrame frame;
+    CanardTxQueueItem* next;
+    CanardCANFrame frame;
 };
 
 /**
@@ -45,14 +32,14 @@ struct CanardTxQueueItem
  * Local node ID will be set to zero, i.e. the node will be anonymous.
  */
 void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size,
-                  CanardOnTransferReception on_reception, CanardShouldAcceptTransfer should_accept)
+                CanardOnTransferReception on_reception, CanardShouldAcceptTransfer should_accept)
 {
-  out_ins->node_id = CANARD_BROADCAST_NODE_ID;
-  out_ins->on_reception = on_reception;
-  out_ins->should_accept = should_accept;
-  out_ins->rx_states = NULL;
-  out_ins->tx_queue = NULL;
-  canardInitPoolAllocator(&out_ins->allocator, mem_arena, mem_arena_size/CANARD_MEM_BLOCK_SIZE);
+    out_ins->node_id = CANARD_BROADCAST_NODE_ID;
+    out_ins->on_reception = on_reception;
+    out_ins->should_accept = should_accept;
+    out_ins->rx_states = NULL;
+    out_ins->tx_queue = NULL;
+    canardInitPoolAllocator(&out_ins->allocator, mem_arena, mem_arena_size / CANARD_MEM_BLOCK_SIZE);
 }
 
 /**
@@ -60,7 +47,7 @@ void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size
  */
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id)
 {
-  ins->node_id = self_node_id;
+    ins->node_id = self_node_id;
 }
 
 /**
@@ -69,60 +56,62 @@ void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id)
  */
 uint8_t canardGetLocalNodeID(const CanardInstance* ins)
 {
-  return ins->node_id;
+    return ins->node_id;
 }
 
 /**
  * Sends a broadcast transfer.
  * If the node is in passive mode, only single frame transfers will be allowed.
  */
- int canardBroadcast(CanardInstance* ins,
-                      uint64_t data_type_signature,
-                      uint16_t data_type_id,
-                      uint8_t* inout_transfer_id,
-                      uint8_t priority,
-                      const void* payload,
-                      uint16_t payload_len)
- {
-  uint32_t can_id;
-  uint16_t crc = 0xFFFFU;
+int canardBroadcast(CanardInstance* ins,
+                    uint64_t data_type_signature,
+                    uint16_t data_type_id,
+                    uint8_t* inout_transfer_id,
+                    uint8_t priority,
+                    const void* payload,
+                    uint16_t payload_len)
+{
+    uint32_t can_id;
+    uint16_t crc = 0xFFFFU;
 
-  if (payload == NULL)
-  {
-      return -1;
-  }
-  if (priority > 31)
-  {
-      return -1;
-  }
-  if (canardGetLocalNodeID(ins) == 0)
-  { 
-    if (payload_len > 7)
+    if (payload == NULL)
     {
-      return -1;
-    } else 
-    {
-      //anonymous transfer, random discriminator
-      uint16_t discriminator = (crcAdd(0xFFFFU, payload, payload_len)) & 0x7FFEU;
-      can_id = ((uint32_t)priority << 24) | (uint32_t)(discriminator << 9) |
-        ((uint32_t)(data_type_id & 0xFF) << 8) | (uint32_t)canardGetLocalNodeID(ins);
+        return -1;
     }
-  } else
-  {
-    can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 8) | (uint32_t)canardGetLocalNodeID(ins);
-    
-    if (payload_len > 7)
+    if (priority > 31)
     {
-      crc = crcAddSignature(crc, data_type_signature);
-      crc = crcAdd(crc, payload, payload_len);
+        return -1;
     }
-  }
+    if (canardGetLocalNodeID(ins) == 0)
+    {
+        if (payload_len > 7)
+        {
+            return -1;
+        }
+        else
+        {
+            // anonymous transfer, random discriminator
+            uint16_t discriminator = (crcAdd(0xFFFFU, payload, payload_len)) & 0x7FFEU;
+            can_id = ((uint32_t)priority << 24) | (uint32_t)(discriminator << 9) |
+                     ((uint32_t)(data_type_id & 0xFF) << 8) | (uint32_t)canardGetLocalNodeID(ins);
+        }
+    }
+    else
+    {
+        can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 8) | (uint32_t)canardGetLocalNodeID(ins);
 
-  canardEnqueueData(ins, can_id, inout_transfer_id, crc, payload, payload_len);
+        if (payload_len > 7)
+        {
+            crc = crcAddSignature(crc, data_type_signature);
+            crc = crcAdd(crc, payload, payload_len);
+        }
+    }
 
-  tidIncrement(inout_transfer_id);
+    canardEnqueueData(ins, can_id, inout_transfer_id, crc, payload, payload_len);
 
-  return 1;
+    tidIncrement(inout_transfer_id);
+
+    return 1;
 }
 
 /**
@@ -130,44 +119,44 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
  * Fails if the node is in passive mode.
  */
 int canardRequestOrRespond(CanardInstance* ins,
-                            uint8_t destination_node_id,
-                            uint64_t data_type_signature,
-                            uint16_t data_type_id,
-                            uint8_t* inout_transfer_id,
-                            uint8_t priority,
-                            CanardRequestResponse kind,
-                            const void* payload,
-                            uint16_t payload_len)
+                           uint8_t destination_node_id,
+                           uint64_t data_type_signature,
+                           uint16_t data_type_id,
+                           uint8_t* inout_transfer_id,
+                           uint8_t priority,
+                           CanardRequestResponse kind,
+                           const void* payload,
+                           uint16_t payload_len)
 {
-  if (payload == NULL)
-  {
-      return -1;
-  }
-  if (canardGetLocalNodeID(ins) == 0)
-  {
-    return -1;
-  }
-  if (priority > 31)
-  {
-      return -1;
-  }
+    if (payload == NULL)
+    {
+        return -1;
+    }
+    if (canardGetLocalNodeID(ins) == 0)
+    {
+        return -1;
+    }
+    if (priority > 31)
+    {
+        return -1;
+    }
 
-  const uint32_t can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 16) | 
-                            ((uint32_t)kind << 15) | ((uint32_t)destination_node_id << 8) | 
-                              (1 << 7) | (uint32_t)canardGetLocalNodeID(ins);
-  uint16_t crc = 0xFFFFU;
+    const uint32_t can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 16) |
+                            ((uint32_t)kind << 15) | ((uint32_t)destination_node_id << 8) |
+                            (1 << 7) | (uint32_t)canardGetLocalNodeID(ins);
+    uint16_t crc = 0xFFFFU;
 
-  if (payload_len > 7)
-  {
-    crc = crcAddSignature(crc, data_type_signature);
-    crc = crcAdd(crc, payload, payload_len);
-  }
+    if (payload_len > 7)
+    {
+        crc = crcAddSignature(crc, data_type_signature);
+        crc = crcAdd(crc, payload, payload_len);
+    }
 
-  canardEnqueueData(ins, can_id, inout_transfer_id, crc, payload, payload_len);
+    canardEnqueueData(ins, can_id, inout_transfer_id, crc, payload, payload_len);
 
-  tidIncrement(inout_transfer_id);
+    tidIncrement(inout_transfer_id);
 
-  return 1;
+    return 1;
 }
 
 /**
@@ -176,21 +165,21 @@ int canardRequestOrRespond(CanardInstance* ins,
  */
 const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins)
 {
-  if (ins->tx_queue == NULL)
-  {
-    return NULL;
-  }
-  return &ins->tx_queue->frame;
+    if (ins->tx_queue == NULL)
+    {
+        return NULL;
+    }
+    return &ins->tx_queue->frame;
 }
 
 /**
  * Removes the top priority frame from the TX queue.
  */
-void canardPopTxQueue(CanardInstance* ins) 
+void canardPopTxQueue(CanardInstance* ins)
 {
-  CanardTxQueueItem* item = ins->tx_queue;
-  ins->tx_queue = item->next;
-  canardFreeBlock(&ins->allocator, item);
+    CanardTxQueueItem* item = ins->tx_queue;
+    ins->tx_queue = item->next;
+    canardFreeBlock(&ins->allocator, item);
 }
 
 /**
@@ -198,164 +187,167 @@ void canardPopTxQueue(CanardInstance* ins)
  */
 void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec)
 {
-  
-  uint8_t transfer_type = canardTransferType(frame->id);
-  uint8_t priority = CANARD_PRIORITY_FROM_ID(frame->id);
-  uint8_t source_node_id = CANARD_SOURCE_ID_FROM_ID(frame->id);
-  uint8_t destination_node_id = (transfer_type == CanardTransferTypeBroadcast) ? 0 : CANARD_DEST_ID_FROM_ID(frame->id);
-  uint16_t data_type_id = canardDataType(frame->id);
-  uint32_t transfer_descriptor = CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id, transfer_type, source_node_id, destination_node_id);
-  
-  CanardRxState* rxstate = NULL;
-  unsigned char tail_byte = frame->data[frame->data_len-1];
+    uint8_t transfer_type = canardTransferType(frame->id);
+    uint8_t priority = CANARD_PRIORITY_FROM_ID(frame->id);
+    uint8_t source_node_id = CANARD_SOURCE_ID_FROM_ID(frame->id);
+    uint8_t destination_node_id = (transfer_type == CanardTransferTypeBroadcast) ? 0 : CANARD_DEST_ID_FROM_ID(frame->id);
+    uint16_t data_type_id = canardDataType(frame->id);
+    uint32_t transfer_descriptor = CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id, transfer_type, source_node_id,
+                                                                   destination_node_id);
 
-  if (IS_START_OF_TRANSFER(tail_byte))
-  {
-    uint64_t data_type_signature;
+    CanardRxState* rxstate = NULL;
+    unsigned char tail_byte = frame->data[frame->data_len - 1];
 
-    if(ins->should_accept(ins, &data_type_signature, data_type_id, transfer_type, source_node_id))
+    if (IS_START_OF_TRANSFER(tail_byte))
     {
-      rxstate = canardRxStateTraversal(ins, transfer_descriptor);
-      rxstate->calculated_crc = crcAddSignature(0xFFFFU, data_type_signature);
+        uint64_t data_type_signature;
+
+        if (ins->should_accept(ins, &data_type_signature, data_type_id, transfer_type, source_node_id))
+        {
+            rxstate = canardRxStateTraversal(ins, transfer_descriptor);
+            rxstate->calculated_crc = crcAddSignature(0xFFFFU, data_type_signature);
+        }
     }
-  } else
-  {
-    rxstate = canardFindRxState(ins->rx_states, transfer_descriptor);
-  }
+    else
+    {
+        rxstate = canardFindRxState(ins->rx_states, transfer_descriptor);
+    }
 
-  if (rxstate == NULL) {
-    return;
-  }
+    if (rxstate == NULL)
+    {
+        return;
+    }
 
+    // Resolving the state flags:
+    const bool not_initialized = (rxstate->timestamp_usec == 0) ? true : false;
+    const bool tid_timed_out = (timestamp_usec - rxstate->timestamp_usec) > TRANSFER_TIMEOUT_USEC;
+    const bool first_frame = IS_START_OF_TRANSFER(tail_byte);
+    const bool not_previous_tid =
+        computeForwardDistance(rxstate->transfer_id, TRANSFER_ID_FROM_TAIL_BYTE(tail_byte)) > 1;
 
-  // Resolving the state flags:
-  const bool not_initialized = (rxstate->timestamp_usec == 0) ? true : false;
-  const bool tid_timed_out = (rxstate->timestamp_usec - timestamp_usec) > TRANSFER_TIMEOUT_USEC;
-  const bool first_frame = IS_START_OF_TRANSFER(tail_byte);
-  const bool not_previous_tid = computeForwardDistance(rxstate->transfer_id, TRANSFER_ID_FROM_TAIL_BYTE(tail_byte)) > 1;
-
-  bool need_restart = 
+    bool need_restart =
         (not_initialized) ||
         (tid_timed_out) ||
         (first_frame && not_previous_tid);
 
-  if (need_restart)
-  {
-    rxstate->transfer_id = TRANSFER_ID_FROM_TAIL_BYTE(tail_byte);
-    rxstate->next_toggle = 0;
-    canardReleaseStatePayload(ins, rxstate);
-    if (!IS_START_OF_TRANSFER(tail_byte)) //missed the first frame
+    if (need_restart)
     {
-      rxstate->transfer_id += 1;
-      if (rxstate->transfer_id >= 32)
-      {
-        rxstate->transfer_id = 0;
-      }
-      return;
+        rxstate->transfer_id = TRANSFER_ID_FROM_TAIL_BYTE(tail_byte);
+        rxstate->next_toggle = 0;
+        canardReleaseStatePayload(ins, rxstate);
+        if (!IS_START_OF_TRANSFER(tail_byte)) // missed the first frame
+        {
+            rxstate->transfer_id += 1;
+            if (rxstate->transfer_id >= 32)
+            {
+                rxstate->transfer_id = 0;
+            }
+            return;
+        }
     }
-  }
 
-  if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte))
-  {  // single frame transfer
-
-    rxstate->timestamp_usec = timestamp_usec;
-    CanardRxTransfer rxtransfer = {
-    .payload_head = frame->data,
-    .payload_len = frame->data_len-1,
-    .data_type_id = data_type_id,
-    .transfer_type = transfer_type,
-    .priority = priority,
-    .source_node_id = source_node_id };
-    ins->on_reception(ins,&rxtransfer);
-
-    canardPrepareForNextTransfer(rxstate);
-    return;
-
-  }
-
-  if (TOGGLE_BIT(tail_byte) != rxstate->next_toggle)
-  {
-    return;  //wrong toggle
-  }
-
-  if (TRANSFER_ID_FROM_TAIL_BYTE(tail_byte) != rxstate->transfer_id)
-  {
-    return;  //unexpected tid
-  }
-
-  if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
-  {  // beginning of multi frame transfer
-    //take off the crc and store the payload
-    rxstate->timestamp_usec = timestamp_usec;
-    canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data+2, frame->data_len-3);
-    rxstate->payload_crc = ((uint16_t)frame->data[0] << 8) | ((uint16_t)frame->data[1]);
-    rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data+2, frame->data_len-3);
-  }
-  else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
-  {
-    canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data, frame->data_len-1);
-    rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data, frame->data_len-1);
-  }
-  else
-  { 
-    CanardRxTransfer rxtransfer = {
-    .timestamp_usec = timestamp_usec,
-    .payload_head = rxstate->buffer_head,
-    .payload_middle = rxstate->buffer_blocks,
-    .payload_tail = frame->data,
-    .middle_len = rxstate->payload_len - CANARD_RX_PAYLOAD_HEAD_SIZE,
-    .payload_len = rxstate->payload_len+frame->data_len-1,
-    .data_type_id = data_type_id,
-    .transfer_type = transfer_type,
-    .priority = priority,
-    .source_node_id = source_node_id };
-    rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data, frame->data_len-1);
-    //crc validation goes here!
-    if (rxstate->calculated_crc == rxstate->payload_crc)
+    if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte)) // single frame transfer
     {
-      ins->on_reception(ins,&rxtransfer);
-    } else
-    {
-      canardReleaseRxTransferPayload(ins, &rxtransfer);
+        rxstate->timestamp_usec = timestamp_usec;
+        CanardRxTransfer rxtransfer = {
+            .payload_head = frame->data,
+            .payload_len = frame->data_len - 1,
+            .data_type_id = data_type_id,
+            .transfer_type = transfer_type,
+            .priority = priority,
+            .source_node_id = source_node_id
+        };
+        ins->on_reception(ins, &rxtransfer);
+
+        canardPrepareForNextTransfer(rxstate);
+        return;
     }
-    canardPrepareForNextTransfer(rxstate);
-    return;
-  }
-  rxstate->next_toggle ^= 1;
+
+    if (TOGGLE_BIT(tail_byte) != rxstate->next_toggle)
+    {
+        return; // wrong toggle
+    }
+
+    if (TRANSFER_ID_FROM_TAIL_BYTE(tail_byte) != rxstate->transfer_id)
+    {
+        return; // unexpected tid
+    }
+
+    if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte)) // beginning of multi frame transfer
+    { // take off the crc and store the payload
+        rxstate->timestamp_usec = timestamp_usec;
+        canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data + 2, frame->data_len - 3);
+        rxstate->payload_crc = ((uint16_t)frame->data[0] << 8) | ((uint16_t)frame->data[1]);
+        rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data + 2, frame->data_len - 3);
+    }
+    else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
+    {
+        canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data, frame->data_len - 1);
+        rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data, frame->data_len - 1);
+    }
+    else
+    {
+        CanardRxTransfer rxtransfer = {
+            .timestamp_usec = timestamp_usec,
+            .payload_head = rxstate->buffer_head,
+            .payload_middle = rxstate->buffer_blocks,
+            .payload_tail = frame->data,
+            .middle_len = rxstate->payload_len - CANARD_RX_PAYLOAD_HEAD_SIZE,
+            .payload_len = rxstate->payload_len + frame->data_len - 1,
+            .data_type_id = data_type_id,
+            .transfer_type = transfer_type,
+            .priority = priority,
+            .source_node_id = source_node_id
+        };
+        rxstate->calculated_crc = crcAdd(rxstate->calculated_crc, frame->data, frame->data_len - 1);
+        // crc validation
+        if (rxstate->calculated_crc == rxstate->payload_crc)
+        {
+            ins->on_reception(ins, &rxtransfer);
+        }
+        else
+        {
+            canardReleaseRxTransferPayload(ins, &rxtransfer);
+        }
+        canardPrepareForNextTransfer(rxstate);
+        return;
+    }
+    rxstate->next_toggle ^= 1;
 }
 
 /**
- * Traverses the list of transfers and removes those that were last updated more than 
+ * Traverses the list of transfers and removes those that were last updated more than
  * timeout_usec microseconds ago
  */
 void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec)
 {
-
-  CanardRxState *prev = ins->rx_states, *state = ins->rx_states;
-  while(state != NULL)
-  {
-    if ((current_time_usec - state->timestamp_usec)>TRANSFER_TIMEOUT_USEC) // two seconds
+    CanardRxState* prev = ins->rx_states, * state = ins->rx_states;
+    while (state != NULL)
     {
-      if (state==ins->rx_states)
-      {
-        canardReleaseStatePayload(ins, state);
-        ins->rx_states = ins->rx_states->next;
-        canardFreeBlock(&ins->allocator, state);
-        state = ins->rx_states;
+        if ((current_time_usec - state->timestamp_usec)>TRANSFER_TIMEOUT_USEC) // two seconds
+        {
+            if (state==ins->rx_states)
+            {
+                canardReleaseStatePayload(ins, state);
+                ins->rx_states = ins->rx_states->next;
+                canardFreeBlock(&ins->allocator, state);
+                state = ins->rx_states;
+                prev = state;
+            }
+            else
+            {
+                canardReleaseStatePayload(ins, state);
+                prev->next = state->next;
+                canardFreeBlock(&ins->allocator, state);
+                state = prev->next;
+            }
+            continue;
+        }
         prev = state;
-      }
-      else
-      {
-        canardReleaseStatePayload(ins, state);
-        prev->next = state->next;
-        canardFreeBlock(&ins->allocator, state);
-        state = prev->next;
-      } 
-      continue;
+        state = state->next;
     }
-    prev = state;
-    state = state->next;
-  }
+}
+
 /**
  * Reads bits (1 to 64) from RX transfer buffer.
  * This function can be used to decode received transfers.
@@ -431,18 +423,19 @@ uint64_t canardReadRxTransferPayload(const CanardRxTransfer* transfer,
  */
 uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer)
 {
-  CanardBufferBlock *temp = transfer->payload_middle;
-  while (transfer->payload_middle != NULL)
-  {
-    temp = transfer->payload_middle->next;
-    canardFreeBlock(&ins->allocator, transfer->payload_middle);
-    transfer->payload_middle = temp;
-  }  transfer->payload_middle = NULL;
+    CanardBufferBlock* temp = transfer->payload_middle;
+    while (transfer->payload_middle != NULL)
+    {
+        temp = transfer->payload_middle->next;
+        canardFreeBlock(&ins->allocator, transfer->payload_middle);
+        transfer->payload_middle = temp;
+    }
+    transfer->payload_middle = NULL;
 
-  transfer->payload_head = NULL;
-  transfer->payload_tail = NULL;
-  transfer->payload_len = 0;
-  return 0;
+    transfer->payload_head = NULL;
+    transfer->payload_tail = NULL;
+    transfer->payload_len = 0;
+    return 0;
 }
 
 /**
@@ -451,17 +444,16 @@ uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* t
  */
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate)
 {
-  CanardBufferBlock *temp = rxstate->buffer_blocks;
-  while (rxstate->buffer_blocks != NULL)
-  {
-    temp = rxstate->buffer_blocks->next;
-    canardFreeBlock(&ins->allocator, rxstate->buffer_blocks);
-    rxstate->buffer_blocks = temp;
-  }
-  rxstate->payload_len = 0;
-  return 0;
+    CanardBufferBlock* temp = rxstate->buffer_blocks;
+    while (rxstate->buffer_blocks != NULL)
+    {
+        temp = rxstate->buffer_blocks->next;
+        canardFreeBlock(&ins->allocator, rxstate->buffer_blocks);
+        rxstate->buffer_blocks = temp;
+    }
+    rxstate->payload_len = 0;
+    return 0;
 }
-
 
 /**
  *  internal (static functions)
@@ -482,80 +474,83 @@ CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b)
     return d;
 }
 
-CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id) 
+CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id)
 {
-  *transfer_id += 1;
-  if (*transfer_id >= 32)
-  {
-    *transfer_id = 0;
-  }
+    *transfer_id += 1;
+    if (*transfer_id >= 32)
+    {
+        *transfer_id = 0;
+    }
 }
 
-CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, 
-                                        uint16_t crc, const uint8_t* payload, uint16_t payload_len)
+CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id,
+                                      uint16_t crc, const uint8_t* payload, uint16_t payload_len)
 {
-  //single frame transfer
-  if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN)
-  {  
+    // single frame transfer
+    if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN)
+    {
+        CanardTxQueueItem* queue_item = canardCreateTxItem(&ins->allocator);
 
-    CanardTxQueueItem* queue_item = canardCreateTxItem(&ins->allocator);
+        if (queue_item == NULL)
+        {
+            return -1;
+        }
 
-    if (queue_item == NULL) {
-      return -1;
+        memcpy(queue_item->frame.data, payload, payload_len);
+
+        queue_item->frame.data_len = payload_len + 1;
+
+        queue_item->frame.data[payload_len] = 0xC0 | (*transfer_id & 31);
+
+        queue_item->frame.id = can_id;
+
+        canardPushTxQueue(ins, queue_item);
     }
+    else if (payload_len >= CANARD_CAN_FRAME_MAX_DATA_LEN)
+    {
+        // multiframe transfer
+        uint8_t i = 2, data_index = 0, toggle = 0, sot_eot = 0x80;
 
-    memcpy(queue_item->frame.data, payload, payload_len);
+        CanardTxQueueItem* queue_item;
 
-    queue_item->frame.data_len = payload_len+1;
+        while (payload_len - data_index != 0)
+        {
+            queue_item = canardCreateTxItem(&ins->allocator);
 
-    queue_item->frame.data[payload_len] = 0xC0 | (*transfer_id & 31);
+            if (queue_item == NULL)
+            {
+                return -1;
+            }
 
-    queue_item->frame.id = can_id;
+            if (data_index == 0)
+            {
+                // add crc
+                queue_item->frame.data[0] = (uint8_t)(crc >> 8);
+                queue_item->frame.data[1] = (uint8_t)(crc);
+                i = 2;
+            }
+            else
+            {
+                i = 0;
+            }
 
-    canardPushTxQueue(ins, queue_item);
+            for (; i<7 && data_index<payload_len; i++, data_index++)
+            {
+                queue_item->frame.data[i] = payload[data_index];
+            }
+            // tail byte
+            sot_eot = (data_index==payload_len) ? 0x40 : sot_eot;
 
-  }
-  else if (payload_len >= CANARD_CAN_FRAME_MAX_DATA_LEN)
-  {
-    //multiframe transfer
-    uint8_t i=2, data_index = 0, toggle = 0, sot_eot = 0x80;
+            queue_item->frame.data[i] = sot_eot | (toggle << 5) | (*transfer_id & 31);
+            queue_item->frame.id = can_id;
+            queue_item->frame.data_len = i + 1;
+            canardPushTxQueue(ins, queue_item);
 
-    CanardTxQueueItem* queue_item;
-
-    while (payload_len - data_index != 0) {
-      queue_item = canardCreateTxItem(&ins->allocator);
-
-      if (queue_item == NULL) {
-        return -1;
-      }
-
-      if (data_index == 0)
-      {
-        //add crc
-        queue_item->frame.data[0] = (uint8_t)(crc >> 8);
-        queue_item->frame.data[1] = (uint8_t)(crc);
-        i = 2;
-      } else {
-        i = 0;
-      }
-
-      for (; i<7 && data_index<payload_len; i++, data_index++)
-      {
-        queue_item->frame.data[i] = payload[data_index];
-      }
-      //tail byte
-      sot_eot = (data_index==payload_len) ? 0x40 : sot_eot;
-
-      queue_item->frame.data[i] = sot_eot | (toggle << 5) | (*transfer_id & 31);
-      queue_item->frame.id = can_id;
-      queue_item->frame.data_len = i+1;
-      canardPushTxQueue(ins,queue_item);
-
-      toggle ^= 1;
-      sot_eot = 0;
+            toggle ^= 1;
+            sot_eot = 0;
+        }
     }
-  }
-  return 1;
+    return 1;
 }
 
 /**
@@ -563,57 +558,58 @@ CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint
  */
 CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item)
 {
-  if (ins->tx_queue == NULL)
-  {
-    ins->tx_queue = item;
-    return;
-  }
-  CanardTxQueueItem* queue = ins->tx_queue;
-  CanardTxQueueItem* previous = ins->tx_queue;
-  while (queue != NULL)
-  {
-    if (priorityHigherThan(queue->frame.id, item->frame.id)) //lower number wins
+    if (ins->tx_queue == NULL)
     {
-      if (queue == ins->tx_queue)
-      {
-        item->next = queue;
         ins->tx_queue = item;
-      }
-      else
-      {
-        previous->next = item;
-        item->next = queue;
-      }
-      return;
-    }
-    else
-    {
-      if (queue->next == NULL)
-      {
-        queue->next = item;
         return;
-      }
-      else
-      {
-        previous = queue;
-        queue = queue->next;
-      }
     }
-  }
+    CanardTxQueueItem* queue = ins->tx_queue;
+    CanardTxQueueItem* previous = ins->tx_queue;
+    while (queue != NULL)
+    {
+        if (priorityHigherThan(queue->frame.id, item->frame.id)) // lower number wins
+        {
+            if (queue == ins->tx_queue)
+            {
+                item->next = queue;
+                ins->tx_queue = item;
+            }
+            else
+            {
+                previous->next = item;
+                item->next = queue;
+            }
+            return;
+        }
+        else
+        {
+            if (queue->next == NULL)
+            {
+                queue->next = item;
+                return;
+            }
+            else
+            {
+                previous = queue;
+                queue = queue->next;
+            }
+        }
+    }
 }
 
 /**
  * creates new tx queue item from allocator
  */
-CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator)
+CANARD_INTERNAL CanardTxQueueItem* canardCreateTxItem(CanardPoolAllocator* allocator)
 {
-  CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
-  if (item == NULL) {
-    return NULL;
-  }
-  memset(item, 0, sizeof *item);
+    CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
+    if (item == NULL)
+    {
+        return NULL;
+    }
+    memset(item, 0, sizeof *item);
 
-  return item;
+    return item;
 }
 
 /**
@@ -621,41 +617,41 @@ CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* alloc
  */
 CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id)
 {
-  const uint32_t clean_id     = id    & CANARD_EXT_ID_MASK;
-  const uint32_t rhs_clean_id = rhs   & CANARD_EXT_ID_MASK;
-  /*
-   * STD vs EXT - if 11 most significant bits are the same, EXT loses.
-   */
-  bool ext     = id     & CANARD_CAN_FRAME_EFF;
-  bool rhs_ext = rhs & CANARD_CAN_FRAME_EFF;
-  if (ext != rhs_ext)
-  {
-    uint32_t arb11     = ext     ? (clean_id >> 18)     : clean_id;
-    uint32_t rhs_arb11 = rhs_ext ? (rhs_clean_id >> 18) : rhs_clean_id;
-    if (arb11 != rhs_arb11)
+    const uint32_t clean_id     = id    & CANARD_EXT_ID_MASK;
+    const uint32_t rhs_clean_id = rhs   & CANARD_EXT_ID_MASK;
+    /*
+     * STD vs EXT - if 11 most significant bits are the same, EXT loses.
+     */
+    bool ext     = id     & CANARD_CAN_FRAME_EFF;
+    bool rhs_ext = rhs & CANARD_CAN_FRAME_EFF;
+    if (ext != rhs_ext)
     {
-        return arb11 < rhs_arb11;
+        uint32_t arb11     = ext     ? (clean_id >> 18)     : clean_id;
+        uint32_t rhs_arb11 = rhs_ext ? (rhs_clean_id >> 18) : rhs_clean_id;
+        if (arb11 != rhs_arb11)
+        {
+            return arb11 < rhs_arb11;
+        }
+        else
+        {
+            return rhs_ext;
+        }
     }
-    else
+
+    /*
+     * RTR vs Data frame - if frame identifiers and frame types are the same, RTR loses.
+     */
+    bool rtr     = id     & CANARD_CAN_FRAME_RTR;
+    bool rhs_rtr = rhs & CANARD_CAN_FRAME_RTR;
+    if (clean_id == rhs_clean_id && rtr != rhs_rtr)
     {
-        return rhs_ext;
+        return rhs_rtr;
     }
-  }
 
-  /*
-   * RTR vs Data frame - if frame identifiers and frame types are the same, RTR loses.
-   */
-  bool rtr     = id     & CANARD_CAN_FRAME_RTR;
-  bool rhs_rtr = rhs & CANARD_CAN_FRAME_RTR;
-  if (clean_id == rhs_clean_id && rtr != rhs_rtr)
-  {
-    return rhs_rtr;
-  }
-
-  /*
-   * Plain ID arbitration - greater value loses.
-   */
-  return clean_id < rhs_clean_id;
+    /*
+     * Plain ID arbitration - greater value loses.
+     */
+    return clean_id < rhs_clean_id;
 }
 
 /**
@@ -663,15 +659,15 @@ CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id)
  */
 CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state)
 {
-  state->buffer_blocks = NULL;  //payload should be empty anyway
-  state->transfer_id += 1;
-  if (state->transfer_id >= 32)
-  {
-    state->transfer_id = 0;
-  }
-  state->payload_len = 0;
-  state->next_toggle = 0;
-  return;
+    state->buffer_blocks = NULL; // payload should be empty anyway
+    state->transfer_id += 1;
+    if (state->transfer_id >= 32)
+    {
+        state->transfer_id = 0;
+    }
+    state->payload_len = 0;
+    state->next_toggle = 0;
+    return;
 }
 
 /**
@@ -679,14 +675,15 @@ CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state)
  */
 CANARD_INTERNAL uint16_t canardDataType(uint32_t id)
 {
-  uint8_t transfer_type = canardTransferType(id);
-  if (transfer_type == CanardTransferTypeBroadcast)
-  {
-    return (uint16_t)CANARD_MSG_TYPE_FROM_ID(id);
-  } else
-  {
-    return (uint16_t)CANARD_SRV_TYPE_FROM_ID(id);
-  }
+    uint8_t transfer_type = canardTransferType(id);
+    if (transfer_type == CanardTransferTypeBroadcast)
+    {
+        return (uint16_t)CANARD_MSG_TYPE_FROM_ID(id);
+    }
+    else
+    {
+        return (uint16_t)CANARD_SRV_TYPE_FROM_ID(id);
+    }
 }
 
 /**
@@ -694,19 +691,19 @@ CANARD_INTERNAL uint16_t canardDataType(uint32_t id)
  */
 CANARD_INTERNAL uint8_t canardTransferType(uint32_t id)
 {
-  uint8_t is_service= (uint8_t)CANARD_SERVICE_NOT_MSG_FROM_ID(id);
-  if (is_service == 0)
-  {
-    return CanardTransferTypeBroadcast;
-  }
-  else if (CANARD_REQUEST_NOT_RESPONSE_FROM_ID(id) == 1)
-  {
-    return CanardTransferTypeRequest;
-  }
-  else
-  {
-    return CanardTransferTypeResponse;
-  }
+    uint8_t is_service = (uint8_t)CANARD_SERVICE_NOT_MSG_FROM_ID(id);
+    if (is_service == 0)
+    {
+        return CanardTransferTypeBroadcast;
+    }
+    else if (CANARD_REQUEST_NOT_RESPONSE_FROM_ID(id) == 1)
+    {
+        return CanardTransferTypeRequest;
+    }
+    else
+    {
+        return CanardTransferTypeResponse;
+    }
 }
 
 /**
@@ -714,155 +711,162 @@ CANARD_INTERNAL uint8_t canardTransferType(uint32_t id)
  */
 
 /**
- * Traverses the list of CanardRxState's and returns a pointer to the CanardRxState 
+ * Traverses the list of CanardRxState's and returns a pointer to the CanardRxState
  * with either the Id or a new one at the end
  */
-CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor)
+CANARD_INTERNAL CanardRxState* canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor)
 {
-  CanardRxState* states = ins->rx_states;
+    CanardRxState* states = ins->rx_states;
 
-  if (states==NULL)
-  {           //initialize CanardRxStates
-    states = canardCreateRxState(&ins->allocator, transfer_descriptor);
-    ins->rx_states = states;
-    return states;
-  }
+    if (states==NULL) // initialize CanardRxStates
+    {
+        states = canardCreateRxState(&ins->allocator, transfer_descriptor);
+        ins->rx_states = states;
+        return states;
+    }
 
-  states = canardFindRxState(states, transfer_descriptor);
-  if (states != NULL)
-  {
-    return states;
-  }
-  else
-  {
-    return canardPrependRxState(ins, transfer_descriptor);
-  }
+    states = canardFindRxState(states, transfer_descriptor);
+    if (states != NULL)
+    {
+        return states;
+    }
+    else
+    {
+        return canardPrependRxState(ins, transfer_descriptor);
+    }
 }
 
 /**
  * returns pointer to the rx state of transfer descriptor or null if not found
  */
-CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor)
+CANARD_INTERNAL CanardRxState* canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor)
 {
-  while(state != NULL)
-  {
-    if(state->dtid_tt_snid_dnid == transfer_descriptor)
+    while (state != NULL)
     {
-      return state;
+        if (state->dtid_tt_snid_dnid == transfer_descriptor)
+        {
+            return state;
+        }
+        state = state->next;
     }
-    state = state->next;
-  }
-  return NULL;
+    return NULL;
 }
 
 /**
  * prepends rx state to the canard instance rx_states
  */
-CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor)
+CANARD_INTERNAL CanardRxState* canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor)
 {
-  CanardRxState* state = canardCreateRxState(&ins->allocator, transfer_descriptor);
-  state->next = ins->rx_states;
-  ins->rx_states = state;
-  return state;
+    CanardRxState* state = canardCreateRxState(&ins->allocator, transfer_descriptor);
+    state->next = ins->rx_states;
+    ins->rx_states = state;
+    return state;
 }
 
-CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor)
+CANARD_INTERNAL CanardRxState* canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor)
 {
-  CanardRxState init = {.next = NULL, .buffer_blocks = NULL, .dtid_tt_snid_dnid = transfer_descriptor};
-  CanardRxState* state = (CanardRxState *)canardAllocateBlock(allocator);
+    CanardRxState init = { .next = NULL, .buffer_blocks = NULL, .dtid_tt_snid_dnid = transfer_descriptor };
+    CanardRxState* state = (CanardRxState*)canardAllocateBlock(allocator);
 
-  if (state == NULL) {
-    return NULL;
-  }
-  memcpy(state, &init, sizeof *state);
+    if (state == NULL)
+    {
+        return NULL;
+    }
+    memcpy(state, &init, sizeof *state);
 
-  return state;
+    return state;
 }
 
 /**
  *  CanardBufferBlock functions
  */
 
- /**
+/**
  * pushes data into the rx state. Fills the buffer head, then appends data to buffer blocks
  */
-CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len)
+CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state,
+                                                const uint8_t* data,
+                                                uint8_t data_len)
 {
-  uint16_t data_index = 0;
-  uint16_t i;
+    uint16_t data_index = 0;
+    uint16_t i;
 
-  // if head is not full, add data to head
-  if ((int)CANARD_RX_PAYLOAD_HEAD_SIZE - (int)state->payload_len > 0) {
-    for (i=state->payload_len; i<CANARD_RX_PAYLOAD_HEAD_SIZE && data_index<data_len; i++, data_index++) 
+    // if head is not full, add data to head
+    if ((int)CANARD_RX_PAYLOAD_HEAD_SIZE - (int)state->payload_len > 0)
     {
-      state->buffer_head[i] = data[data_index];
-    }
-    if (data_index >= data_len-1) {
-      state->payload_len += data_len;
-      return;
-    }
-  } //head is full.
+        for (i = state->payload_len; i<CANARD_RX_PAYLOAD_HEAD_SIZE && data_index<data_len; i++, data_index++)
+        {
+            state->buffer_head[i] = data[data_index];
+        }
+        if (data_index >= data_len /*- 1*/)
+        {
+            state->payload_len += data_len;
+            return;
+        }
+    } // head is full.
 
-  uint8_t num_buffer_blocks = (((state->payload_len + data_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) / CANARD_BUFFER_BLOCK_DATA_SIZE)+1;
-  uint8_t index_at_nth_block = (((state->payload_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) % CANARD_BUFFER_BLOCK_DATA_SIZE);
+    uint8_t num_buffer_blocks =
+        (((state->payload_len + data_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) / CANARD_BUFFER_BLOCK_DATA_SIZE) + 1;
+    uint8_t index_at_nth_block = (((state->payload_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) % CANARD_BUFFER_BLOCK_DATA_SIZE);
 
-  //get to current block
-  CanardBufferBlock* block;
-  uint8_t nth_block = 1;
-  
-  //buffer blocks uninitialized
-  if (state->buffer_blocks == NULL)
-  {
-    state->buffer_blocks = canardCreateBufferBlock(allocator);
-    block = state->buffer_blocks;
-    index_at_nth_block = 0;
-  }
-  else
-  {
-    //get to block
-    block = state->buffer_blocks;
-    while (block->next != NULL)
-    {
-      nth_block++;
-      block = block->next;
-    }
-    if (num_buffer_blocks > nth_block && index_at_nth_block == 0)
-    {
-      block->next = canardCreateBufferBlock(allocator);
-      block = block->next;
-      nth_block++;
-    }
-  }
+    // get to current block
+    CanardBufferBlock* block;
+    uint8_t nth_block = 1;
 
-  // add data to current block until it becomes full, add new block if necessary
-  while (data_index < data_len)
-  {
-    for (i=index_at_nth_block; i<CANARD_BUFFER_BLOCK_DATA_SIZE && data_index<data_len; i++, data_index++)
+    // buffer blocks uninitialized
+    if (state->buffer_blocks == NULL)
     {
-      block->data[i] = data[data_index];
+        state->buffer_blocks = canardCreateBufferBlock(allocator);
+        block = state->buffer_blocks;
+        index_at_nth_block = 0;
     }
-    if (data_index < data_len)
+    else
     {
-      block->next = canardCreateBufferBlock(allocator);
-      block = block->next;
-      index_at_nth_block = 0;
+        // get to block
+        block = state->buffer_blocks;
+        while (block->next != NULL)
+        {
+            nth_block++;
+            block = block->next;
+        }
+        if (num_buffer_blocks > nth_block && index_at_nth_block == 0)
+        {
+            block->next = canardCreateBufferBlock(allocator);
+            block = block->next;
+            nth_block++;
+        }
     }
-  }
-  state->payload_len += data_len;
-  return;
+
+    // add data to current block until it becomes full, add new block if necessary
+    while (data_index < data_len)
+    {
+        for (i = index_at_nth_block; i<CANARD_BUFFER_BLOCK_DATA_SIZE && data_index<data_len; i++, data_index++)
+        {
+            block->data[i] = data[data_index];
+        }
+        if (data_index < data_len)
+        {
+            block->next = canardCreateBufferBlock(allocator);
+            block = block->next;
+            index_at_nth_block = 0;
+        }
+    }
+    state->payload_len += data_len;
+    return;
 }
 
 /**
  * creates new buffer block
  */
-CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator)
+CANARD_INTERNAL CanardBufferBlock* canardCreateBufferBlock(CanardPoolAllocator* allocator)
 {
-  CanardBufferBlock* block = (CanardBufferBlock *)canardAllocateBlock(allocator);
-  if (block == NULL) {
-    return NULL;
-  }
-  block->next = NULL;
-  return block;
+    CanardBufferBlock* block = (CanardBufferBlock*)canardAllocateBlock(allocator);
+    if (block == NULL)
+    {
+        return NULL;
+    }
+    block->next = NULL;
+    return block;
 }
 
 /**
@@ -870,46 +874,46 @@ CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* 
  */
 CANARD_INTERNAL uint16_t crcAddByte(uint16_t crc_val, uint8_t byte)
 {
-  crc_val ^= (uint16_t)((uint16_t)(byte) << 8);
-  int j;
-  for (j=0; j<8; j++)
-  {
-      if (crc_val & 0x8000U)
-      {
-          crc_val = (uint16_t)((uint16_t)(crc_val << 1) ^ 0x1021U);
-      }
-      else
-      {
-          crc_val = (uint16_t)(crc_val << 1);
-      }
-  }
-  return crc_val;
+    crc_val ^= (uint16_t)((uint16_t)(byte) << 8);
+    int j;
+    for (j = 0; j<8; j++)
+    {
+        if (crc_val & 0x8000U)
+        {
+            crc_val = (uint16_t)((uint16_t)(crc_val << 1) ^ 0x1021U);
+        }
+        else
+        {
+            crc_val = (uint16_t)(crc_val << 1);
+        }
+    }
+    return crc_val;
 }
 
 CANARD_INTERNAL uint16_t crcAddSignature(uint16_t crc_val, uint64_t data_type_signature)
 {
-  int shift_val;
-  for (shift_val=56; shift_val>0; shift_val-=8)
-  {
-    crc_val = crcAddByte(crc_val, (uint8_t)(data_type_signature >> shift_val));
-  }
-  return crc_val;
+    int shift_val;
+    for (shift_val = 56; shift_val>0; shift_val -= 8)
+    {
+        crc_val = crcAddByte(crc_val, (uint8_t)(data_type_signature >> shift_val));
+    }
+    return crc_val;
 }
 
 CANARD_INTERNAL uint16_t crcAdd(uint16_t crc_val, const uint8_t* bytes, uint16_t len)
 {
-  while (len--)
-  {
-      crc_val = crcAddByte(crc_val,*bytes++);
-  }
-  return crc_val;
+    while (len--)
+    {
+        crc_val = crcAddByte(crc_val, *bytes++);
+    }
+    return crc_val;
 }
 
 /**
  *  Pool Allocator functions
  */
-
-CANARD_INTERNAL void canardInitPoolAllocator(CanardPoolAllocator* allocator, CanardPoolAllocatorBlock* buf, unsigned int buf_len)
+CANARD_INTERNAL void canardInitPoolAllocator(CanardPoolAllocator* allocator, CanardPoolAllocatorBlock* buf,
+                                             unsigned int buf_len)
 {
     unsigned int current_index = 0;
     CanardPoolAllocatorBlock** current_block = &(allocator->free_list);

--- a/src/canard.c
+++ b/src/canard.c
@@ -44,6 +44,7 @@ struct CanardTxQueueItem
  * Initializes the library state.
  * Local node ID will be set to zero, i.e. the node will be anonymous.
  */
+void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept)
 void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception)
 {
   out_ins->node_id = CANARD_BROADCAST_NODE_ID;

--- a/src/canard.c
+++ b/src/canard.c
@@ -721,8 +721,8 @@ CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocato
  */
 CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len)
 {
-  uint8_t data_index = 0;
-  uint8_t i;
+  uint16_t data_index = 0;
+  uint16_t i;
 
   // if head is not full, add data to head
   if ((int)CANARD_RX_PAYLOAD_HEAD_SIZE - (int)state->payload_len > 0) {

--- a/src/canard.c
+++ b/src/canard.c
@@ -105,7 +105,6 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
       can_id = ((uint32_t)priority << 24) | (uint32_t)(discriminator << 9) |
         ((uint32_t)(data_type_id & 0xFF) << 8) | (uint32_t)canardGetLocalNodeID(ins);
     }
-  }
   } else
   {
     can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 8) | (uint32_t)canardGetLocalNodeID(ins);
@@ -233,7 +232,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
     rxstate->transfer_id = TRANSFER_ID_FROM_TAIL_BYTE(tail_byte);
     rxstate->next_toggle = 0;
     canardReleaseStatePayload(ins, rxstate);
-    if (!IS_START_OF_TRANSFER(tail_byte))
+    if (!IS_START_OF_TRANSFER(tail_byte)) //missed the first frame
     {
       rxstate->transfer_id += 1;
       if (rxstate->transfer_id >= 32)
@@ -412,7 +411,6 @@ CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id)
 
 CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, 
                                         uint16_t crc, const uint8_t* payload, uint16_t payload_len)
-CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, const uint8_t* payload, uint16_t payload_len)
 {
   //single frame transfer
   if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN)

--- a/src/canard.c
+++ b/src/canard.c
@@ -257,13 +257,13 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
  * Traverses the list of transfers and removes those that were last updated more than 
  * timeout_usec microseconds ago
  */
-void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t timeout_usec, uint64_t current_time_usec)
+void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec)
 {
 
   CanardRxState *prev = ins->rx_states, *state = ins->rx_states;
   while(state != NULL)
   {
-    if ((current_time_usec - state->timestamp_usec)>timeout_usec)
+    if ((current_time_usec - state->timestamp_usec)>TRANSFER_TIMEOUT_USEC) // two seconds
     {
       if (state==ins->rx_states)
       {

--- a/src/canard.c
+++ b/src/canard.c
@@ -1,7 +1,10 @@
+/*
+ * Copyright (C) 2015 Michael Sierra <sierramichael.a@gmail.com>
+ */
+
+
 #include "canard.h"
 #include "canard_internals.h"
-// #include <inttypes.h>
-
 
 #define CANARD_MAKE_TRANSFER_DESCRIPTOR(data_type_id, transfer_type, \
                                         src_node_id, dst_node_id) \
@@ -22,7 +25,8 @@ struct CanardTxQueueItem
  * Initializes the library state.
  * Local node ID will be set to zero, i.e. the node will be anonymous.
  */
-void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception) {
+void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception)
+{
   out_ins->node_id = CANARD_BROADCAST_NODE_ID;
   out_ins->on_reception = on_reception;
   out_ins->rx_states = NULL;
@@ -33,7 +37,8 @@ void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception)
 /**
  * Assigns a new node ID value to the current node.
  */
-void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id) {
+void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id)
+{
   ins->node_id = self_node_id;
 }
 
@@ -41,7 +46,8 @@ void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id) {
  * Returns node ID of the local node.
  * Returns zero if the node ID has not been set.
  */
-uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
+uint8_t canardGetLocalNodeID(const CanardInstance* ins)
+{
   return ins->node_id;
 }
 
@@ -54,7 +60,8 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
                       uint8_t* inout_transfer_id,
                       uint8_t priority,
                       const uint8_t* payload,
-                      uint16_t payload_len) {
+                      uint16_t payload_len)
+ {
   if (payload == NULL)
   {
       return -1;
@@ -69,7 +76,8 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
 
   const uint32_t can_id = ((uint32_t)priority << 24) | ((uint32_t)data_type_id << 8) | (uint32_t)canardGetLocalNodeID(ins);
   //single frame transfer
-  if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN) {  
+  if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN)
+  {  
 
     CanardTxQueueItem* queue_item = canardCreateTxItem(&ins->allocator);
 
@@ -81,14 +89,11 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
 
     queue_item->frame.id = can_id;
 
-    *inout_transfer_id += 1;
-    if (*inout_transfer_id >= 32) {
-      *inout_transfer_id = 0;
-    }
-
     canardPushTxQueue(ins, queue_item);
 
-  } else if (payload_len >= CANARD_CAN_FRAME_MAX_DATA_LEN){
+  }
+  else if (payload_len >= CANARD_CAN_FRAME_MAX_DATA_LEN)
+  {
     //multiframe transfer
     uint8_t i=2, data_index = 0, toggle = 0, sot_eot = 0x80;
 
@@ -97,24 +102,21 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
     while (payload_len - data_index != 0) {
       frame = canardCreateTxItem(&ins->allocator);
 
-      if (data_index == 0) {
+      if (data_index == 0)
+      {
         frame->frame.data[0] = 0xFF;
-        frame->frame.data[1] = 0XFF;
+        frame->frame.data[1] = 0XDD;
         i = 2;
       } else {
         i = 0;
       }
 
-      for (; i<7 && data_index<payload_len; i++, data_index++) {
+      for (; i<7 && data_index<payload_len; i++, data_index++)
+      {
         frame->frame.data[i] = payload[data_index];
       }
 
       sot_eot = (data_index==payload_len) ? 0x40: sot_eot;
-
-      *inout_transfer_id += 1;
-      if (*inout_transfer_id >= 32) {
-        *inout_transfer_id = 0;
-      }
 
       frame->frame.data[i] = sot_eot | (toggle << 5) | (*inout_transfer_id & 31);
       frame->frame.id = can_id;
@@ -125,6 +127,8 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
       sot_eot = 0;
     }
   }
+  tidIncrement(inout_transfer_id);
+
   return 1;
 }
 
@@ -132,8 +136,10 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins) {
  * Returns a pointer to the top priority frame in the TX queue.
  * Returns NULL if the TX queue is empty.
  */
-const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins) {
-  if (ins->tx_queue == NULL) {
+const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins)
+{
+  if (ins->tx_queue == NULL)
+  {
     return NULL;
   }
   return &ins->tx_queue->frame;
@@ -142,7 +148,8 @@ const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins) {
 /**
  * Removes the top priority frame from the TX queue.
  */
-void canardPopTxQueue(CanardInstance* ins) {
+void canardPopTxQueue(CanardInstance* ins) 
+{
   CanardTxQueueItem* item = ins->tx_queue;
   ins->tx_queue = item->next;
   canardFreeBlock(&ins->allocator, item);
@@ -151,7 +158,8 @@ void canardPopTxQueue(CanardInstance* ins) {
 /**
  * Processes a received CAN frame with a timestamp.
  */
-void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec) {
+void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec)
+{
   
   uint8_t transfer_type = canardTransferType(frame->id);
   uint8_t priority = CANARD_PRIORITY_FROM_ID(frame->id);
@@ -164,7 +172,39 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
   unsigned char tail_byte = frame->data[frame->data_len-1];
   rxstate = canardRxStateTraversal(ins, frame, transfer_descriptor);
 
-  if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte)) {  // single frame transfer
+  // // Resolving the state flags:
+  const bool not_initialized = (rxstate->timestamp_usec == 0) ? true : false;
+  // const bool tid_timed_out = (rxstate->timestamp_usec - timestamp_usec) > TRANSFER_TIMEOUT_USEC;
+  const bool first_frame = IS_START_OF_TRANSFER(tail_byte);
+  const bool not_previous_tid = computeForwardDistance(rxstate->transfer_id, TRANSFER_ID_FROM_TAIL_BYTE(tail_byte)) > 1;
+
+  //printf("tid: %u\n",TRANSFER_ID_FROM_TAIL_BYTE(tail_byte));
+  //printf("tid: %u\n",rxstate->transfer_id);
+  bool need_restart = 
+        (not_initialized) ||
+        // (tid_timed_out) ||
+        (first_frame && not_previous_tid);
+
+  if (need_restart)
+  {
+    printf("intializing\n");
+    rxstate->transfer_id = TRANSFER_ID_FROM_TAIL_BYTE(tail_byte);
+    rxstate->next_toggle = 0;
+    canardReleaseStatePayload(ins, rxstate);
+    if (!IS_START_OF_TRANSFER(tail_byte))
+    {
+      rxstate->transfer_id += 1;
+      if (rxstate->transfer_id >= 32)
+      {
+        rxstate->transfer_id = 0;
+      } 
+      printf("not start of transfer, ignoring\n");
+      return;
+    }
+  }
+
+  if (IS_START_OF_TRANSFER(tail_byte) && IS_END_OF_TRANSFER(tail_byte))
+  {  // single frame transfer
 
     rxstate->timestamp_usec = timestamp_usec;
     CanardRxTransfer rxtransfer = {
@@ -176,46 +216,111 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
     .source_node_id = source_node_id };
     ins->on_reception(ins,&rxtransfer);
 
-  } else if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte)) {  // beginning of multi frame transfer
+    canardPrepareForNextTransfer(rxstate);
+    return;
+
+  }
+
+  if (TOGGLE_BIT(tail_byte) != rxstate->next_toggle)
+  {
+    printf("Invalid toggle, returning.");
+    return;
+  }
+
+  if (TRANSFER_ID_FROM_TAIL_BYTE(tail_byte) != rxstate->transfer_id)
+  {
+    printf("Invalid transfer id, returning.");
+    return;
+  }
+
+  if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
+  {  // beginning of multi frame transfer
     //take off the crc and store the payload
     rxstate->timestamp_usec = timestamp_usec;
-
     canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data+2, frame->data_len-3);
 
-  } else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte)) {
+  }
+  else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))
+  {
 
     canardBufferBlockPushBytes(&ins->allocator, rxstate, frame->data, frame->data_len-1);
 
-  } else { 
+  }
+  else
+  { 
     CanardRxTransfer rxtransfer = {
     .timestamp_usec = timestamp_usec,
     .payload_head = rxstate->buffer_head,
     .payload_middle = rxstate->buffer_blocks,
     .payload_tail = frame->data,
+    .middle_len = rxstate->payload_len - CANARD_RX_PAYLOAD_HEAD_SIZE,
     .payload_len = rxstate->payload_len+frame->data_len-1,
     .data_type_id = data_type_id,
     .transfer_type = transfer_type,
     .priority = priority,
     .source_node_id = source_node_id };
 
-    cleanCanardRxState(rxstate);
-
     ins->on_reception(ins,&rxtransfer);
+
+    canardPrepareForNextTransfer(rxstate);
+
+    return;
   }
+  rxstate->next_toggle ^= 1;
 }
 
+/**
+ * Traverses the list of transfers and removes those that were last updated more than 
+ * timeout_usec microseconds ago
+ */
+void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t timeout_usec, uint64_t current_time_usec)
+{
+
+  CanardRxState *prev = ins->rx_states, *state = ins->rx_states;
+  while(state != NULL)
+  {
+    if ((current_time_usec - state->timestamp_usec)>timeout_usec)
+    {
+      //printf("cleaning up %u\n",state->dtid_tt_snid_dnid);
+      if (state==ins->rx_states)
+      {
+        canardReleaseStatePayload(ins, state);
+        ins->rx_states = ins->rx_states->next;
+        canardFreeBlock(&ins->allocator, state);
+        state = ins->rx_states;
+        prev = state;
+      }
+      else
+      {
+        canardReleaseStatePayload(ins, state);
+        prev->next = state->next;
+        canardFreeBlock(&ins->allocator, state);
+        state = prev->next;
+      } 
+      continue;
+    }
+    prev = state;
+    state = state->next;
+  }
+}
 
 /**
  * This function can be invoked by the application to release pool blocks that are used
  * to store the payload of this transfer
  */
-uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer) {
-  CanardBufferBlock *block, *temp = transfer->payload_middle;
-  while (block != NULL) {
-    block = temp;
-    temp = block->next;
-    canardFreeBlock(&ins->allocator, block);
+uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer)
+{
+  CanardBufferBlock *temp = transfer->payload_middle;
+  //canardPrintBlocks(transfer->payload_middle);
+  static uint64_t i = 0;
+  while (transfer->payload_middle != NULL)
+  {
+    temp = transfer->payload_middle->next;
+    canardFreeBlock(&ins->allocator, transfer->payload_middle);
+    transfer->payload_middle = temp;
   }
+  printf("%lu\n",i);
+  i++;
   transfer->payload_middle = NULL;
   transfer->payload_head = NULL;
   transfer->payload_tail = NULL;
@@ -224,36 +329,88 @@ uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* t
 }
 
 /**
+ * This function can be invoked by the application to release pool blocks that are used
+ * to store the payload of this transfer
+ */
+CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate)
+{
+  CanardBufferBlock *temp = rxstate->buffer_blocks;
+  while (rxstate->buffer_blocks != NULL)
+  {
+    temp = rxstate->buffer_blocks->next;
+    canardFreeBlock(&ins->allocator, rxstate->buffer_blocks);
+    rxstate->buffer_blocks = temp;
+  }
+  rxstate->payload_len = 0;
+  return 0;
+}
+
+
+/**
  *  internal (static functions)
  *
  *
  */
 
 /**
+ * TransferID
+ */
+CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b)
+{
+    int d = b - a;
+    if (d < 0)
+    {
+        d += 1 << TRANSFER_ID_BIT_LEN;
+    }
+    return d;
+}
+
+CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id) 
+{
+  *transfer_id += 1;
+  if (*transfer_id >= 32)
+  {
+    *transfer_id = 0;
+  }
+}
+
+/**
  * Puts frame on on the TX queue. Higher priority placed first
  */
-CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item) {
-  if (ins->tx_queue == NULL) {
+CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item)
+{
+  if (ins->tx_queue == NULL)
+  {
     ins->tx_queue = item;
     return;
   }
   CanardTxQueueItem* queue = ins->tx_queue;
   CanardTxQueueItem* previous = ins->tx_queue;
-  while (queue != NULL) {
-    if (priorityHigherThan(queue->frame.id, item->frame.id)) {
-      if (queue == ins->tx_queue) {
+  while (queue != NULL)
+  {
+    if (priorityHigherThan(queue->frame.id, item->frame.id))
+    {
+      if (queue == ins->tx_queue)
+      {
         item->next = queue;
         ins->tx_queue = item;
-      } else {
+      }
+      else
+      {
         previous->next = item;
         item->next = queue;
       }
       return;
-    } else {
-      if (queue->next == NULL) {
+    }
+    else
+    {
+      if (queue->next == NULL)
+      {
         queue->next = item;
         return;
-      } else {
+      }
+      else
+      {
         previous = queue;
         queue = queue->next;
       }
@@ -264,7 +421,8 @@ CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* i
 /**
  * creates new tx queue item from allocator
  */
-CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator) {
+CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator)
+{
   CanardTxQueueItem init = {0};
   CanardTxQueueItem* item = (CanardTxQueueItem*)canardAllocateBlock(allocator);
 
@@ -276,7 +434,8 @@ CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* alloc
 /**
  * returns true if priority of rhs is higher than id
  */
-CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id) {
+CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id)
+{
   const uint32_t clean_id     = id    & CANARD_EXT_ID_MASK;
   const uint32_t rhs_clean_id = rhs   & CANARD_EXT_ID_MASK;
   /*
@@ -317,21 +476,32 @@ CANARD_INTERNAL bool priorityHigherThan(uint32_t rhs, uint32_t id) {
 /**
  * preps the rx state for the next transfer. does not delete the state
  */
-CANARD_INTERNAL void cleanCanardRxState(CanardRxState* state) {
-  state->buffer_blocks = NULL;
+CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state)
+{
+  state->buffer_blocks = NULL;  //payload should be empty anyway
+  //printf("bufferblocks: %p\n",state->buffer_blocks);
+  //canardPrintBlocks(state->buffer_blocks);
+  state->transfer_id += 1;
+  if (state->transfer_id >= 32)
+  {
+    state->transfer_id = 0;
+  }
   state->payload_len = 0;
-  state->transfer_id = 0;
   state->next_toggle = 0;
+  return;
 }
 
 /**
  * returns data type from id
  */
-CANARD_INTERNAL uint16_t canardDataType(uint32_t id) {
+CANARD_INTERNAL uint16_t canardDataType(uint32_t id)
+{
   uint8_t transfer_type = canardTransferType(id);
-  if (transfer_type == CanardTransferTypeBroadcast) {
+  if (transfer_type == CanardTransferTypeBroadcast)
+  {
     return (uint16_t)CANARD_MSG_TYPE_FROM_ID(id);
-  } else {
+  } else
+  {
     return (uint16_t)CANARD_SRV_TYPE_FROM_ID(id);
   }
 }
@@ -339,13 +509,19 @@ CANARD_INTERNAL uint16_t canardDataType(uint32_t id) {
 /**
  * returns transfer type from id
  */
-CANARD_INTERNAL uint8_t canardTransferType(uint32_t id) {
+CANARD_INTERNAL uint8_t canardTransferType(uint32_t id)
+{
   uint8_t is_service= (uint8_t)CANARD_SERVICE_NOT_MSG_FROM_ID(id);
-  if (is_service == 0) {
+  if (is_service == 0)
+  {
     return CanardTransferTypeBroadcast;
-  } else if (CANARD_REQUEST_NOT_RESPONSE_FROM_ID(id) == 1) {
+  }
+  else if (CANARD_REQUEST_NOT_RESPONSE_FROM_ID(id) == 1)
+  {
     return CanardTransferTypeRequest;
-  } else {
+  }
+  else
+  {
     return CanardTransferTypeResponse;
   }
 }
@@ -358,19 +534,24 @@ CANARD_INTERNAL uint8_t canardTransferType(uint32_t id) {
  * Traverses the list of CanardRxState's and returns a pointer to the CanardRxState 
  * with either the Id or a new one at the end
  */
-CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor) {
+CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor)
+{
   CanardRxState* states = ins->rx_states;
 
-  if (states==NULL) {           //initialize CanardRxStates
+  if (states==NULL)
+  {           //initialize CanardRxStates
     states = canardCreateRxState(&ins->allocator, transfer_descriptor);
     ins->rx_states = states;
     return states;
   }
 
   states = canardFindRxState(states, transfer_descriptor);
-  if (states != NULL) {
+  if (states != NULL)
+  {
     return states;
-  } else {
+  }
+  else
+  {
     return canardAppendRxState(ins, transfer_descriptor);
   }
 }
@@ -378,9 +559,12 @@ CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const
 /**
  * returns pointer to the rx state of transfer descriptor or null if not found
  */
-CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor) {
-  while(state != NULL) {
-    if(state->dtid_tt_snid_dnid == transfer_descriptor) {
+CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor)
+{
+  while(state != NULL)
+  {
+    if(state->dtid_tt_snid_dnid == transfer_descriptor)
+    {
       return state;
     }
     state = state->next;
@@ -391,15 +575,18 @@ CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t 
 /**
  * appends rx state to the canard instance rx_states
  */
-CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor) {
+CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor)
+{
   CanardRxState* states = ins->rx_states;
   static int i = 1;
-  if(states->next == NULL) {
+  if(states->next == NULL)
+  {
     states->next = canardCreateRxState(&ins->allocator, transfer_descriptor);
     return states->next;
   }
 
-  while(states->next != NULL) {
+  while(states->next != NULL)
+  {
     states = states->next;
   }
   i++;
@@ -407,7 +594,8 @@ CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t
   return states->next;
 }
 
-CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor) {
+CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor)
+{
   CanardRxState init = {.next = NULL, .buffer_blocks = NULL, .dtid_tt_snid_dnid = transfer_descriptor};
   CanardRxState* state = (CanardRxState *)canardAllocateBlock(allocator);
 
@@ -423,14 +611,21 @@ CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocato
  /**
  * pushes data into the rx state. Fills the buffer head, then appends data to buffer blocks
  */
-CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len) {
+CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len)
+{
   uint8_t data_index = 0;
   uint8_t i;
 
+  // printf("buffer block size: %lu\n", CANARD_BUFFER_BLOCK_DATA_SIZE);
+  // printf("payload size: %u\n", state->payload_len);
+  //printf("difference: %i\n",(int)CANARD_RX_PAYLOAD_HEAD_SIZE - (int)state->payload_len);
   // if head is not full, add data to head
-  if (CANARD_RX_PAYLOAD_HEAD_SIZE - state->payload_len > 0) {
-    for (i=state->payload_len; i<CANARD_RX_PAYLOAD_HEAD_SIZE && data_index<data_len; i++, data_index++) {
+  if ((int)CANARD_RX_PAYLOAD_HEAD_SIZE - (int)state->payload_len > 0) {
+    //printf("uh oh, we're here");
+    for (i=state->payload_len; i<CANARD_RX_PAYLOAD_HEAD_SIZE && data_index<data_len; i++, data_index++) 
+    {
       state->buffer_head[i] = data[data_index];
+      // printf("put %u at head, %u\n", data[data_index], i);
     }
     if (data_index >= data_len-1) {
       state->payload_len += data_len;
@@ -439,21 +634,34 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
   } //head is full.
 
   uint8_t num_buffer_blocks = (((state->payload_len + data_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) / CANARD_BUFFER_BLOCK_DATA_SIZE)+1;
-  uint8_t index_at_nth_block = ((state->payload_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) % CANARD_BUFFER_BLOCK_DATA_SIZE;
-    
+  uint8_t index_at_nth_block = (((state->payload_len) - CANARD_RX_PAYLOAD_HEAD_SIZE) % CANARD_BUFFER_BLOCK_DATA_SIZE);
+
+  // printf("buffer block size%lu \n",CANARD_BUFFER_BLOCK_DATA_SIZE);
+  // printf("payload size: %u\n", state->payload_len+ data_len);
+  // printf("num_buffer_blocks: %u\n", num_buffer_blocks);
+  // printf("index_at_nth_block: %u\n", index_at_nth_block);
+
+
   //get to current block
   CanardBufferBlock* block;
   uint8_t nth_block = 1;
-  if (state->buffer_blocks == NULL) {
+  
+  if (state->buffer_blocks == NULL)
+  {
     state->buffer_blocks = canardCreateBufferBlock(allocator);
     block = state->buffer_blocks;
-  } else {
+    index_at_nth_block = 0;
+  }
+  else
+  {
     block = state->buffer_blocks;
-    while (block->next != NULL) {
+    while (block->next != NULL)
+    {
       nth_block++;
       block = block->next;
     }
-    if (num_buffer_blocks > nth_block && index_at_nth_block == 0) {
+    if (num_buffer_blocks > nth_block && index_at_nth_block == 0)
+    {
       block->next = canardCreateBufferBlock(allocator);
       block = block->next;
       nth_block++;
@@ -461,16 +669,22 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
   }
 
   // add data to current block until it becomes full, add new block if necessary
-  while (data_index < data_len) {
-    for (i=index_at_nth_block; i<CANARD_BUFFER_BLOCK_DATA_SIZE && data_index<data_len; i++, data_index++) {
+  while (data_index < data_len)
+  {
+    for (i=index_at_nth_block; i<CANARD_BUFFER_BLOCK_DATA_SIZE && data_index<data_len; i++, data_index++)
+    {
       block->data[i] = data[data_index];
+      //printf("put %u at block, %u\n", data[data_index], i);
+      // printf("placed: %u at %i index of %p block \n", data[data_index], i, block);
     }
-    if (data_index < data_len) {
+    if (data_index < data_len)
+    {
       block->next = canardCreateBufferBlock(allocator);
       block = block->next;
       index_at_nth_block = 0;
     }
   }
+  //canardPrintBlocks(state->buffer_blocks);
   state->payload_len += data_len;
   return;
 }
@@ -478,7 +692,8 @@ CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, 
 /**
  * creates new buffer block
  */
-CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator) {
+CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator)
+{
   CanardBufferBlock* block = (CanardBufferBlock *)canardAllocateBlock(allocator);
   block->next = NULL;
   return block;
@@ -522,4 +737,21 @@ CANARD_INTERNAL void canardFreeBlock(CanardPoolAllocator* allocator, void* p)
 
     block->next = allocator->free_list;
     allocator->free_list = block;
+}
+
+
+void canardPrintBlocks(CanardBufferBlock* nblock) {
+  CanardBufferBlock* block = nblock;
+  if (block == NULL) {
+    printf("empty\n");
+  }
+  else {
+    while(block != NULL) {
+      printf("{(current: %p), ", block);
+      printf("(next: %p), ", block->next);
+      //printf("(id: %02X) ", queue->frame.id);
+      block = block->next;
+    }
+  }
+  printf("\n");
 }

--- a/src/canard.c
+++ b/src/canard.c
@@ -94,9 +94,6 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
     {
       //anonymous transfer, random discriminator
     }
-  if (canardGetLocalNodeID(ins) == 0 && payload_len > 7)
-  {
-    return -1;
   }
   if (priority > 31)
   {

--- a/src/canard.h
+++ b/src/canard.h
@@ -5,8 +5,187 @@
 extern "C" {
 #endif
 
+//#include <std.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+
 /** The size of a memory block in bytes. */
 #define CANARD_MEM_BLOCK_SIZE 32
+
+#define CANARD_AVAILABLE_BLOCKS 32
+
+#define CANARD_CAN_FRAME_MAX_DATA_LEN 8
+
+#define CANARD_BROADCAST_NODE_ID    0
+#define CANARD_MIN_NODE_ID          1
+#define CANARD_MAX_NODE_ID          127
+
+#define CANARD_EXT_ID_MASK       0x1FFFFFFFU
+#define CANARD_CAN_FRAME_EFF    (1U << 31)  //extended frame format
+#define CANARD_CAN_FRAME_RTR    (1U << 30)  //remote transmission
+#define CANARD_CAN_FRAME_ERR    (1U << 29)  //error frame
+
+#define CANARD_SOURCE_ID_FROM_ID(x) (x) & (0X7F)
+#define CANARD_SERVICE_NOT_MSG_FROM_ID(x)   (((x) >> 7)  & 0X1)
+#define CANARD_REQUEST_NOT_RESPONSE_FROM_ID(x) (((x) >> 15) & 0X1)
+#define CANARD_DEST_ID_FROM_ID(x)   (((x) >> 8)  & 0X7F)
+#define CANARD_PRIORITY_FROM_ID(x)  (((x) >> 24) & 0X1F)
+#define CANARD_MSG_TYPE_FROM_ID(x)  (((x) >> 8)  & 0XFFFF)
+#define CANARD_SRV_TYPE_FROM_ID(x)  (((x) >> 16)  & 0XFF)
+
+#define TRANSFER_ID_FROM_TAIL_BYTE(x) ((x) & 0X1F)
+
+#define IS_START_OF_TRANSFER(x) (((x) >> 7) & 0X1)
+#define IS_END_OF_TRANSFER(x) (((x) >> 6) & 0X1)
+
+#define CANARD_RX_PAYLOAD_HEAD_SIZE (CANARD_MEM_BLOCK_SIZE - sizeof(CanardRxState))
+#define CANARD_BUFFER_BLOCK_DATA_SIZE (CANARD_MEM_BLOCK_SIZE - sizeof(CanardBufferBlock))
+
+typedef struct
+{
+  uint32_t id;
+  uint8_t data[CANARD_CAN_FRAME_MAX_DATA_LEN];
+  uint8_t data_len;
+} CanardCANFrame;
+
+typedef enum
+{
+  CanardTransferTypeResponse  = 0,
+  CanardTransferTypeRequest   = 1,
+  CanardTransferTypeBroadcast = 2
+} CanardTransferType;
+
+typedef enum
+{
+  CanardResponse,
+  CanardRequest
+} CanardRequestResponse;
+
+typedef struct CanardInstance CanardInstance;
+typedef struct CanardRxTransfer CanardRxTransfer;
+typedef struct CanardRxState CanardRxState;
+typedef struct CanardTxQueueItem CanardTxQueueItem;
+
+typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins, uint16_t data_type_id, CanardTransferType transfer_type, uint8_t source_node_id);
+typedef void (*canardOnTransferReception)(CanardInstance* ins, CanardRxTransfer* transfer);
+
+/** A memory block used in the memory block allocator. */
+typedef union CanardPoolAllocatorBlock_u
+{
+    char bytes[CANARD_MEM_BLOCK_SIZE];
+    union CanardPoolAllocatorBlock_u* next;
+} CanardPoolAllocatorBlock;
+
+typedef struct
+{
+    CanardPoolAllocatorBlock* free_list;
+} CanardPoolAllocator;
+
+/** buffer block for rx data. */
+typedef struct CanardBufferBlock 
+{
+  struct CanardBufferBlock* next;
+  uint8_t data[];
+} CanardBufferBlock;
+
+struct CanardRxState
+{
+  struct CanardRxState* next;
+  CanardBufferBlock* buffer_blocks;
+
+  uint64_t timestamp_usec;
+
+  uint32_t dtid_tt_snid_dnid;
+  // const uint32_t dtid_tt_snid_dnid;
+
+  uint16_t payload_crc;
+  uint16_t payload_len : 10;
+  uint16_t transfer_id : 5;
+  uint16_t next_toggle : 1;
+
+  uint8_t buffer_head[];
+};
+
+/**
+ * This structure maintains the current canard instance of this node including the node_ID,
+ * a function pointer, should_accept, which the application uses to decide whether to keep this or subsequent frames,
+ * a function pointer, on_reception, which hands a completed transfer to the application,
+ * the allocator and its blocks,
+ * and
+ * the CanardRxState list
+ */
+struct CanardInstance
+{
+  uint8_t node_id;  // local node
+
+  canardShouldAcceptTransferPtr should_accept; 						// function to decide whether we want this transfer
+  canardOnTransferReception on_reception;        					// function we call after rx transfer is complete
+
+  CanardPoolAllocator allocator;									// pool allocator
+  CanardPoolAllocatorBlock buffer[CANARD_AVAILABLE_BLOCKS];			// pool blocks
+
+  CanardRxState* rx_states;
+  CanardTxQueueItem* tx_queue;
+};
+
+
+/**
+ * This structure represents a received transfer for the application.
+ * An instance of it is passed to the application via callback when
+ * the library receives a new transfer.
+ */
+struct CanardRxTransfer
+{
+    /**
+     * Timestamp at which the first frame of this transfer was received.
+     */
+    uint64_t timestamp_usec;
+
+    /**
+     * Payload is scattered across three storages:
+     *  - Head points to CanardRxState.buffer_head (length of which is up to Canard_PAYLOAD_HEAD_SIZE), or to the
+     *    payload field (possibly with offset) of the last received CAN frame.
+     *  - Middle is located in the linked list of dynamic blocks.
+     *  - Tail points to the payload field (possibly with offset) of the last received CAN frame
+     *    (only for multi-frame transfers).
+     *
+     * The tail offset depends on how much data of the last frame was accommodated in the last allocated
+     * block.
+     *
+     * For single-frame transfers, middle and tail will be NULL, and the head will point at first byte
+     * of the payload of the CAN frame.
+     *
+     * In simple cases it should be possible to get data directly from the head and/or tail pointers.
+     * Otherwise it is advised to use canardReadRxTransferPayload().
+     */
+    const uint8_t*           payload_head;   ///< Always valid, i.e. not NULL.
+    CanardBufferBlock* payload_middle; ///< May be NULL if the buffer was not needed. Always NULL for single-frame transfers.
+    const uint8_t*           payload_tail;   ///< Last bytes of multi-frame transfers. Always NULL for single-frame transfers.
+    uint16_t payload_len;
+
+    /**
+     * These fields identify the transfer for the application logic.
+     */
+    uint16_t data_type_id;                  ///< 0 to 255 for services, 0 to 65535 for messages
+    uint8_t transfer_type;                  ///< See @ref CanardTransferType
+    uint8_t transfer_id;                    ///< 0 to 31
+    uint8_t priority;                       ///< 0 to 31
+    uint8_t source_node_id;                 ///< 1 to 127, or 0 if the source is anonymous
+};
+
+void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception);
+void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
+uint8_t canardGetLocalNodeID(const CanardInstance* ins);
+void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec);
+int canardBroadcast(CanardInstance* ins, uint16_t data_type_id, uint8_t* inout_transfer_id, uint8_t priority, const uint8_t* payload, uint16_t payload_len);
+const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
+void canardPopTxQueue(CanardInstance* ins);
+uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer);
 
 #ifdef __cplusplus
 }

--- a/src/canard.h
+++ b/src/canard.h
@@ -1,26 +1,12 @@
 /*
- * The MIT License (MIT)
- * 
  * Copyright (c) 2016 UAVCAN Team
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- * 
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ *
+ * Distributed under the MIT License, available in the file LICENSE.
+ *
+ * Author: Michael Sierra <sierramichael.a@gmail.com>
+ *
  */
+
 
 #ifndef CANARD_H
 #define CANARD_H
@@ -51,22 +37,22 @@ extern "C" {
 
 typedef struct
 {
-  uint32_t id;
-  uint8_t data[CANARD_CAN_FRAME_MAX_DATA_LEN];
-  uint8_t data_len;
+    uint32_t id;
+    uint8_t data[CANARD_CAN_FRAME_MAX_DATA_LEN];
+    uint8_t data_len;
 } CanardCANFrame;
 
 typedef enum
 {
-  CanardTransferTypeResponse  = 0,
-  CanardTransferTypeRequest   = 1,
-  CanardTransferTypeBroadcast = 2
+    CanardTransferTypeResponse  = 0,
+    CanardTransferTypeRequest   = 1,
+    CanardTransferTypeBroadcast = 2
 } CanardTransferType;
 
 typedef enum
 {
-  CanardResponse,
-  CanardRequest
+    CanardResponse,
+    CanardRequest
 } CanardRequestResponse;
 
 typedef struct CanardInstance CanardInstance;
@@ -78,10 +64,10 @@ typedef struct CanardTxQueueItem CanardTxQueueItem;
  * The library calls this function to determine whether the transfer should be received.
  */
 typedef bool (*CanardShouldAcceptTransfer)(const CanardInstance* ins,
-                                                uint64_t* out_data_type_signature,
-                                                uint16_t data_type_id, 
-                                                CanardTransferType transfer_type, 
-                                                uint8_t source_node_id);
+                                           uint64_t* out_data_type_signature,
+                                           uint16_t data_type_id,
+                                           CanardTransferType transfer_type,
+                                           uint8_t source_node_id);
 
 /**
  * This function will be invoked by the library every time a transfer is successfully received.
@@ -104,29 +90,31 @@ typedef struct
 } CanardPoolAllocator;
 
 /** buffer block for rx data. */
-typedef struct CanardBufferBlock 
+typedef struct CanardBufferBlock
 {
-  struct CanardBufferBlock* next;
-  uint8_t data[];
+    struct CanardBufferBlock* next;
+
+    uint8_t data[];
 } CanardBufferBlock;
 
 struct CanardRxState
 {
-  struct CanardRxState* next;
-  CanardBufferBlock* buffer_blocks;
+    struct CanardRxState* next;
 
-  uint64_t timestamp_usec;
+    CanardBufferBlock* buffer_blocks;
 
-  //uint32_t dtid_tt_snid_dnid;
-  const uint32_t dtid_tt_snid_dnid;
+    uint64_t timestamp_usec;
 
-  uint16_t payload_crc;
-  uint16_t calculated_crc;
-  uint16_t payload_len : 10;
-  uint16_t transfer_id : 5;
-  uint16_t next_toggle : 1;
+    // uint32_t dtid_tt_snid_dnid;
+    const uint32_t dtid_tt_snid_dnid;
 
-  uint8_t buffer_head[];
+    uint16_t payload_crc;
+    uint16_t calculated_crc;
+    uint16_t payload_len : 10;
+    uint16_t transfer_id : 5;
+    uint16_t next_toggle : 1;
+
+    uint8_t buffer_head[];
 };
 
 /**
@@ -139,15 +127,18 @@ struct CanardRxState
  */
 struct CanardInstance
 {
-  uint8_t node_id;  // local node
+    uint8_t node_id; // local node
 
-  CanardShouldAcceptTransfer should_accept; 						// function to decide whether we want this transfer
-  CanardOnTransferReception on_reception;        					// function we call after rx transfer is complete
+    CanardShouldAcceptTransfer should_accept;                                           // function to decide whether we
+                                                                                        // want this transfer
+    CanardOnTransferReception on_reception;                                             // function we call after rx
+                                                                                        // transfer is complete
 
-  CanardPoolAllocator allocator;									// pool allocator
+    CanardPoolAllocator allocator;                                                                      // pool
+                                                                                                        // allocator
 
-  CanardRxState* rx_states;
-  CanardTxQueueItem* tx_queue;
+    CanardRxState* rx_states;
+    CanardTxQueueItem* tx_queue;
 };
 
 
@@ -180,30 +171,36 @@ struct CanardRxTransfer
      * In simple cases it should be possible to get data directly from the head and/or tail pointers.
      * Otherwise it is advised to use canardReadRxTransferPayload().
      */
-    const uint8_t*           payload_head;   ///< Always valid, i.e. not NULL.
-    CanardBufferBlock* payload_middle; ///< May be NULL if the buffer was not needed. Always NULL for single-frame transfers.
-    const uint8_t*           payload_tail;   ///< Last bytes of multi-frame transfers. Always NULL for single-frame transfers.
+    const uint8_t*           payload_head;   // /< Always valid, i.e. not NULL.
+    CanardBufferBlock* payload_middle; // /< May be NULL if the buffer was not needed. Always NULL for single-frame
+                                       // transfers.
+    const uint8_t*           payload_tail;   // /< Last bytes of multi-frame transfers. Always NULL for single-frame
+                                             // transfers.
     uint16_t payload_len;
     uint16_t middle_len;
 
     /**
      * These fields identify the transfer for the application logic.
      */
-    uint16_t data_type_id;                  ///< 0 to 255 for services, 0 to 65535 for messages
-    uint8_t transfer_type;                  ///< See @ref CanardTransferType
-    uint8_t transfer_id;                    ///< 0 to 31
-    uint8_t priority;                       ///< 0 to 31
-    uint8_t source_node_id;                 ///< 1 to 127, or 0 if the source is anonymous
+    uint16_t data_type_id;                  // /< 0 to 255 for services, 0 to 65535 for messages
+    uint8_t transfer_type;                  // /< See @ref CanardTransferType
+    uint8_t transfer_id;                    // /< 0 to 31
+    uint8_t priority;                       // /< 0 to 31
+    uint8_t source_node_id;                 // /< 1 to 127, or 0 if the source is anonymous
 };
 
 void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size,
-                  CanardOnTransferReception on_reception, CanardShouldAcceptTransfer should_accept);
+                CanardOnTransferReception on_reception, CanardShouldAcceptTransfer should_accept);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
-int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature,uint16_t data_type_id, uint8_t* inout_transfer_id, 
-                              uint8_t priority, const void* payload, uint16_t payload_len);
-int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uint64_t data_type_signature, uint16_t data_type_id, uint8_t* inout_transfer_id, 
-                              uint8_t priority, CanardRequestResponse kind, const void* payload, uint16_t payload_len);
+int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature, uint16_t data_type_id,
+                    uint8_t* inout_transfer_id,
+                    uint8_t priority, const void* payload,
+                    uint16_t payload_len);
+int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uint64_t data_type_signature,
+                           uint16_t data_type_id, uint8_t* inout_transfer_id,
+                           uint8_t priority, CanardRequestResponse kind, const void* payload,
+                           uint16_t payload_len);
 const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
 void canardPopTxQueue(CanardInstance* ins);
 void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec);

--- a/src/canard.h
+++ b/src/canard.h
@@ -1,5 +1,25 @@
 /*
- * Copyright (C) 2015 Michael Sierra <sierramichael.a@gmail.com>
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 UAVCAN Team
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. 
  */
 
 #ifndef CANARD_H
@@ -9,7 +29,6 @@
 extern "C" {
 #endif
 
-//#include <std.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdint.h>

--- a/src/canard.h
+++ b/src/canard.h
@@ -77,7 +77,7 @@ typedef struct CanardTxQueueItem CanardTxQueueItem;
 /**
  * The library calls this function to determine whether the transfer should be received.
  */
-typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins,
+typedef bool (*CanardShouldAcceptTransfer)(const CanardInstance* ins,
                                                 uint64_t* out_data_type_signature,
                                                 uint16_t data_type_id, 
                                                 CanardTransferType transfer_type, 
@@ -89,7 +89,7 @@ typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins,
  * to call canardReleaseRxTransferPayload() first, so that the memory that was used for the block
  * buffer can be released and re-used by the TX queue.
  */
-typedef void (*canardOnTransferReception)(CanardInstance* ins, CanardRxTransfer* transfer);
+typedef void (*CanardOnTransferReception)(CanardInstance* ins, CanardRxTransfer* transfer);
 
 /** A memory block used in the memory block allocator. */
 typedef union CanardPoolAllocatorBlock_u
@@ -141,8 +141,8 @@ struct CanardInstance
 {
   uint8_t node_id;  // local node
 
-  canardShouldAcceptTransferPtr should_accept; 						// function to decide whether we want this transfer
-  canardOnTransferReception on_reception;        					// function we call after rx transfer is complete
+  CanardShouldAcceptTransfer should_accept; 						// function to decide whether we want this transfer
+  CanardOnTransferReception on_reception;        					// function we call after rx transfer is complete
 
   CanardPoolAllocator allocator;									// pool allocator
 
@@ -197,7 +197,7 @@ struct CanardRxTransfer
 };
 
 void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size,
-                  canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept);
+                  CanardOnTransferReception on_reception, CanardShouldAcceptTransfer should_accept);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
 int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature,uint16_t data_type_id, uint8_t* inout_transfer_id, 

--- a/src/canard.h
+++ b/src/canard.h
@@ -174,7 +174,7 @@ struct CanardRxTransfer
     CanardBufferBlock* payload_middle; ///< May be NULL if the buffer was not needed. Always NULL for single-frame transfers.
     const uint8_t*           payload_tail;   ///< Last bytes of multi-frame transfers. Always NULL for single-frame transfers.
     uint16_t payload_len;
-    uint8_t middle_len;
+    uint16_t middle_len;
 
     /**
      * These fields identify the transfer for the application logic.

--- a/src/canard.h
+++ b/src/canard.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdbool.h>
 
 /** The size of a memory block in bytes. */
-#define CANARD_MEM_BLOCK_SIZE 40  //size must be at least 40 on 64 bit machines
+#define CANARD_MEM_BLOCK_SIZE 32
 #define CANARD_AVAILABLE_BLOCKS 32
 
 #define CANARD_CAN_FRAME_MAX_DATA_LEN 8

--- a/src/canard.h
+++ b/src/canard.h
@@ -208,6 +208,7 @@ const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
 void canardPopTxQueue(CanardInstance* ins);
 void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec);
 void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec);
+uint64_t canardReadRxTransferPayload(const CanardRxTransfer* transfer, uint16_t bit_offset, uint8_t bit_length);
 uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer);
 
 #ifdef __cplusplus

--- a/src/canard.h
+++ b/src/canard.h
@@ -75,10 +75,20 @@ typedef struct CanardRxTransfer CanardRxTransfer;
 typedef struct CanardRxState CanardRxState;
 typedef struct CanardTxQueueItem CanardTxQueueItem;
 
+/**
+ * The library calls this function to determine whether the transfer should be received.
+ */
 typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins, 
                                                 uint16_t data_type_id, 
                                                 CanardTransferType transfer_type, 
                                                 uint8_t source_node_id);
+
+/**
+ * This function will be invoked by the library every time a transfer is successfully received.
+ * If the application needs to send another transfer from this callback, it is recommended
+ * to call canardReleaseRxTransferPayload() first, so that the memory that was used for the block
+ * buffer can be released and re-used by the TX queue.
+ */
 typedef void (*canardOnTransferReception)(CanardInstance* ins, CanardRxTransfer* transfer);
 
 /** A memory block used in the memory block allocator. */

--- a/src/canard.h
+++ b/src/canard.h
@@ -78,7 +78,8 @@ typedef struct CanardTxQueueItem CanardTxQueueItem;
 /**
  * The library calls this function to determine whether the transfer should be received.
  */
-typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins, 
+typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins,
+                                                uint64_t* out_data_type_signature,
                                                 uint16_t data_type_id, 
                                                 CanardTransferType transfer_type, 
                                                 uint8_t source_node_id);
@@ -196,7 +197,7 @@ struct CanardRxTransfer
     uint8_t source_node_id;                 ///< 1 to 127, or 0 if the source is anonymous
 };
 
-void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception);
+void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
 int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature,uint16_t data_type_id, uint8_t* inout_transfer_id, 

--- a/src/canard.h
+++ b/src/canard.h
@@ -22,33 +22,11 @@ extern "C" {
 #define CANARD_MEM_BLOCK_SIZE 32
 #define CANARD_AVAILABLE_BLOCKS 32
 
-#define TRANSFER_TIMEOUT_USEC 2000000
-
 #define CANARD_CAN_FRAME_MAX_DATA_LEN 8
-#define TRANSFER_ID_BIT_LEN 5
 
 #define CANARD_BROADCAST_NODE_ID    0
 #define CANARD_MIN_NODE_ID          1
 #define CANARD_MAX_NODE_ID          127
-
-#define CANARD_EXT_ID_MASK       0x1FFFFFFFU
-#define CANARD_CAN_FRAME_EFF    (1U << 31)  //extended frame format
-#define CANARD_CAN_FRAME_RTR    (1U << 30)  //remote transmission
-#define CANARD_CAN_FRAME_ERR    (1U << 29)  //error frame
-
-#define CANARD_SOURCE_ID_FROM_ID(x) (x) & (0X7F)
-#define CANARD_SERVICE_NOT_MSG_FROM_ID(x)   (((x) >> 7)  & 0X1)
-#define CANARD_REQUEST_NOT_RESPONSE_FROM_ID(x) (((x) >> 15) & 0X1)
-#define CANARD_DEST_ID_FROM_ID(x)   (((x) >> 8)  & 0X7F)
-#define CANARD_PRIORITY_FROM_ID(x)  (((x) >> 24) & 0X1F)
-#define CANARD_MSG_TYPE_FROM_ID(x)  (((x) >> 8)  & 0XFFFF)
-#define CANARD_SRV_TYPE_FROM_ID(x)  (((x) >> 16)  & 0XFF)
-
-#define TRANSFER_ID_FROM_TAIL_BYTE(x) ((x) & 0X1F)
-
-#define IS_START_OF_TRANSFER(x) (((x) >> 7) & 0X1)
-#define IS_END_OF_TRANSFER(x) (((x) >> 6) & 0X1)
-#define TOGGLE_BIT(x) (((x) >> 5) & 0X1)
 
 #define CANARD_RX_PAYLOAD_HEAD_SIZE (CANARD_MEM_BLOCK_SIZE - sizeof(CanardRxState))
 #define CANARD_BUFFER_BLOCK_DATA_SIZE (CANARD_MEM_BLOCK_SIZE - sizeof(CanardBufferBlock))

--- a/src/canard.h
+++ b/src/canard.h
@@ -39,7 +39,6 @@ extern "C" {
 
 /** The size of a memory block in bytes. */
 #define CANARD_MEM_BLOCK_SIZE 32
-#define CANARD_AVAILABLE_BLOCKS 32
 
 #define CANARD_CAN_FRAME_MAX_DATA_LEN 8
 
@@ -146,7 +145,6 @@ struct CanardInstance
   canardOnTransferReception on_reception;        					// function we call after rx transfer is complete
 
   CanardPoolAllocator allocator;									// pool allocator
-  CanardPoolAllocatorBlock buffer[CANARD_AVAILABLE_BLOCKS];			// pool blocks
 
   CanardRxState* rx_states;
   CanardTxQueueItem* tx_queue;
@@ -198,7 +196,8 @@ struct CanardRxTransfer
     uint8_t source_node_id;                 ///< 1 to 127, or 0 if the source is anonymous
 };
 
-void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept);
+void canardInit(CanardInstance* out_ins,  void* mem_arena, size_t mem_arena_size,
+                  canardOnTransferReception on_reception, canardShouldAcceptTransferPtr should_accept);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
 int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature,uint16_t data_type_id, uint8_t* inout_transfer_id, 

--- a/src/canard.h
+++ b/src/canard.h
@@ -75,7 +75,10 @@ typedef struct CanardRxTransfer CanardRxTransfer;
 typedef struct CanardRxState CanardRxState;
 typedef struct CanardTxQueueItem CanardTxQueueItem;
 
-typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins, uint16_t data_type_id, CanardTransferType transfer_type, uint8_t source_node_id);
+typedef bool (*canardShouldAcceptTransferPtr)(const CanardInstance* ins, 
+                                                uint16_t data_type_id, 
+                                                CanardTransferType transfer_type, 
+                                                uint8_t source_node_id);
 typedef void (*canardOnTransferReception)(CanardInstance* ins, CanardRxTransfer* transfer);
 
 /** A memory block used in the memory block allocator. */

--- a/src/canard.h
+++ b/src/canard.h
@@ -199,9 +199,9 @@ struct CanardRxTransfer
 void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
-int canardBroadcast(CanardInstance* ins, uint16_t data_type_id, uint8_t* inout_transfer_id, 
+int canardBroadcast(CanardInstance* ins, uint64_t data_type_signature,uint16_t data_type_id, uint8_t* inout_transfer_id, 
                               uint8_t priority, const void* payload, uint16_t payload_len);
-int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uint16_t data_type_id, uint8_t* inout_transfer_id, 
+int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uint64_t data_type_signature, uint16_t data_type_id, uint8_t* inout_transfer_id, 
                               uint8_t priority, CanardRequestResponse kind, const void* payload, uint16_t payload_len);
 const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
 void canardPopTxQueue(CanardInstance* ins);

--- a/src/canard.h
+++ b/src/canard.h
@@ -196,7 +196,7 @@ int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uin
 const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
 void canardPopTxQueue(CanardInstance* ins);
 void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec);
-void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t timeout_usec, uint64_t current_time_usec);
+void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec);
 uint64_t canardReleaseRxTransferPayload(CanardInstance* ins, CanardRxTransfer* transfer);
 
 #ifdef __cplusplus

--- a/src/canard.h
+++ b/src/canard.h
@@ -38,7 +38,7 @@ extern "C" {
 #include <stdbool.h>
 
 /** The size of a memory block in bytes. */
-#define CANARD_MEM_BLOCK_SIZE 32
+#define CANARD_MEM_BLOCK_SIZE 40  //size must be at least 40 on 64 bit machines
 #define CANARD_AVAILABLE_BLOCKS 32
 
 #define CANARD_CAN_FRAME_MAX_DATA_LEN 8
@@ -122,6 +122,7 @@ struct CanardRxState
   const uint32_t dtid_tt_snid_dnid;
 
   uint16_t payload_crc;
+  uint16_t calculated_crc;
   uint16_t payload_len : 10;
   uint16_t transfer_id : 5;
   uint16_t next_toggle : 1;

--- a/src/canard.h
+++ b/src/canard.h
@@ -189,7 +189,10 @@ struct CanardRxTransfer
 void canardInit(CanardInstance* out_ins, canardOnTransferReception on_reception);
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id);
 uint8_t canardGetLocalNodeID(const CanardInstance* ins);
-int canardBroadcast(CanardInstance* ins, uint16_t data_type_id, uint8_t* inout_transfer_id, uint8_t priority, const uint8_t* payload, uint16_t payload_len);
+int canardBroadcast(CanardInstance* ins, uint16_t data_type_id, uint8_t* inout_transfer_id, 
+                              uint8_t priority, const void* payload, uint16_t payload_len);
+int canardRequestOrRespond(CanardInstance* ins, uint8_t destination_node_id, uint16_t data_type_id, uint8_t* inout_transfer_id, 
+                              uint8_t priority, CanardRequestResponse kind, const void* payload, uint16_t payload_len);
 const CanardCANFrame* canardPeekTxQueue(const CanardInstance* ins);
 void canardPopTxQueue(CanardInstance* ins);
 void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -1,25 +1,25 @@
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2016 UAVCAN Team
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE. 
+ * SOFTWARE.
  */
 
 #ifndef CANARD_INTERNALS_H
@@ -39,42 +39,44 @@ extern "C" {
 
 #define TRANSFER_ID_BIT_LEN 5
 #define CANARD_EXT_ID_MASK       0x1FFFFFFFU
-#define CANARD_CAN_FRAME_EFF    (1U << 31)  //extended frame format
-#define CANARD_CAN_FRAME_RTR    (1U << 30)  //remote transmission
-#define CANARD_CAN_FRAME_ERR    (1U << 29)  //error frame
+#define CANARD_CAN_FRAME_EFF    (1U << 31)  // extended frame format
+#define CANARD_CAN_FRAME_RTR    (1U << 30)  // remote transmission
+#define CANARD_CAN_FRAME_ERR    (1U << 29)  // error frame
 
-#define CANARD_SOURCE_ID_FROM_ID(x) (x) & (0X7F)
-#define CANARD_SERVICE_NOT_MSG_FROM_ID(x)   (((x) >> 7)  & 0X1)
-#define CANARD_REQUEST_NOT_RESPONSE_FROM_ID(x) (((x) >> 15) & 0X1)
-#define CANARD_DEST_ID_FROM_ID(x)   (((x) >> 8)  & 0X7F)
-#define CANARD_PRIORITY_FROM_ID(x)  (((x) >> 24) & 0X1F)
-#define CANARD_MSG_TYPE_FROM_ID(x)  (((x) >> 8)  & 0XFFFF)
-#define CANARD_SRV_TYPE_FROM_ID(x)  (((x) >> 16)  & 0XFF)
+#define CANARD_SOURCE_ID_FROM_ID(x) (x)& (0X7F)
+#define CANARD_SERVICE_NOT_MSG_FROM_ID(x)   (((x) >> 7)& 0X1)
+#define CANARD_REQUEST_NOT_RESPONSE_FROM_ID(x) (((x) >> 15)& 0X1)
+#define CANARD_DEST_ID_FROM_ID(x)   (((x) >> 8)& 0X7F)
+#define CANARD_PRIORITY_FROM_ID(x)  (((x) >> 24)& 0X1F)
+#define CANARD_MSG_TYPE_FROM_ID(x)  (((x) >> 8)& 0XFFFF)
+#define CANARD_SRV_TYPE_FROM_ID(x)  (((x) >> 16)& 0XFF)
 
-#define TRANSFER_ID_FROM_TAIL_BYTE(x) ((x) & 0X1F)
+#define TRANSFER_ID_FROM_TAIL_BYTE(x) ((x)& 0X1F)
 
-#define IS_START_OF_TRANSFER(x) (((x) >> 7) & 0X1)
-#define IS_END_OF_TRANSFER(x) (((x) >> 6) & 0X1)
-#define TOGGLE_BIT(x) (((x) >> 5) & 0X1)
+#define IS_START_OF_TRANSFER(x) (((x) >> 7)& 0X1)
+#define IS_END_OF_TRANSFER(x) (((x) >> 6)& 0X1)
+#define TOGGLE_BIT(x) (((x) >> 5)& 0X1)
 
 
-CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
-CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
-CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor);
-CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
-CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len);
-CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator);
+CANARD_INTERNAL CanardRxState* canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState* canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState* canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState* canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
+CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state,
+                                                const uint8_t* data,
+                                                uint8_t data_len);
+CANARD_INTERNAL CanardBufferBlock* canardCreateBufferBlock(CanardPoolAllocator* allocator);
 CANARD_INTERNAL uint8_t canardTransferType(uint32_t id);
 CANARD_INTERNAL uint16_t canardDataType(uint32_t id);
 CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item);
 CANARD_INTERNAL bool priorityHigherThan(uint32_t id, uint32_t rhs);
-CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator);
+CANARD_INTERNAL CanardTxQueueItem* canardCreateTxItem(CanardPoolAllocator* allocator);
 CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state);
 CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b);
 CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
-CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, uint16_t crc, 
-										const uint8_t* payload, uint16_t payload_len);
+CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, uint16_t crc,
+                                      const uint8_t* payload, uint16_t payload_len);
 CANARD_INTERNAL uint16_t crcAddByte(uint16_t crc_val, uint8_t byte);
 CANARD_INTERNAL uint16_t crcAddSignature(uint16_t crc_val, uint64_t data_type_signature);
 CANARD_INTERNAL uint16_t crcAdd(uint16_t crc_val, const uint8_t* bytes, uint16_t len);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -76,6 +76,7 @@ CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRx
 CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, uint16_t crc, 
 										const uint8_t* payload, uint16_t payload_len);
 CANARD_INTERNAL uint16_t crc_add_byte(uint16_t crc_val, uint8_t byte);
+CANARD_INTERNAL uint16_t crc_add_signature(uint16_t crc_val, uint64_t data_type_signature);
 CANARD_INTERNAL uint16_t crc_add(uint16_t crc_val, const uint8_t* bytes, uint16_t len);
 
 /** Inits a memory allocator.

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -28,6 +28,7 @@ CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state);
 CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b);
 CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
+CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, const uint8_t* payload, uint16_t payload_len);
 
 /** Inits a memory allocator.
  *

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2016 UAVCAN Team
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE. 
+ */
+
 #ifndef CANARD_INTERNALS_H
 #define CANARD_INTERNALS_H
 

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -13,7 +13,7 @@ extern "C" {
 #endif
 
 
-CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -73,7 +73,8 @@ CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state);
 CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b);
 CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
-CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, const uint8_t* payload, uint16_t payload_len);
+CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, uint16_t crc, 
+										const uint8_t* payload, uint16_t payload_len);
 CANARD_INTERNAL uint16_t crc_add_byte(uint16_t crc_val, uint8_t byte);
 CANARD_INTERNAL uint16_t crc_add(uint16_t crc_val, const uint8_t* bytes, uint16_t len);
 

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -17,16 +17,17 @@ CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
-CANARD_INTERNAL void canardPrintStates(CanardInstance* ins);
 CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len);
 CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator);
 CANARD_INTERNAL uint8_t canardTransferType(uint32_t id);
 CANARD_INTERNAL uint16_t canardDataType(uint32_t id);
 CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item);
 CANARD_INTERNAL bool priorityHigherThan(uint32_t id, uint32_t rhs);
-CANARD_INTERNAL void canardPrintQueue(CanardInstance* ins);
 CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator);
-CANARD_INTERNAL void cleanCanardRxState(CanardRxState* state);
+CANARD_INTERNAL void canardPrepareForNextTransfer(CanardRxState* state);
+CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b);
+CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
+CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
 
 /** Inits a memory allocator.
  *

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -15,7 +15,8 @@ extern "C" {
 
 CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
-CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
+// CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
 CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len);
 CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -26,7 +26,6 @@
 #define CANARD_INTERNALS_H
 
 #include <unistd.h>
-//#include "canard.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -75,9 +75,9 @@ CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
 CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, uint16_t crc, 
 										const uint8_t* payload, uint16_t payload_len);
-CANARD_INTERNAL uint16_t crc_add_byte(uint16_t crc_val, uint8_t byte);
-CANARD_INTERNAL uint16_t crc_add_signature(uint16_t crc_val, uint64_t data_type_signature);
-CANARD_INTERNAL uint16_t crc_add(uint16_t crc_val, const uint8_t* bytes, uint16_t len);
+CANARD_INTERNAL uint16_t crcAddByte(uint16_t crc_val, uint8_t byte);
+CANARD_INTERNAL uint16_t crcAddSignature(uint16_t crc_val, uint64_t data_type_signature);
+CANARD_INTERNAL uint16_t crcAdd(uint16_t crc_val, const uint8_t* bytes, uint16_t len);
 
 /** Inits a memory allocator.
  *

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -12,6 +12,28 @@ extern "C" {
 # define CANARD_INTERNAL static
 #endif
 
+#define TRANSFER_TIMEOUT_USEC 2000000
+
+#define TRANSFER_ID_BIT_LEN 5
+#define CANARD_EXT_ID_MASK       0x1FFFFFFFU
+#define CANARD_CAN_FRAME_EFF    (1U << 31)  //extended frame format
+#define CANARD_CAN_FRAME_RTR    (1U << 30)  //remote transmission
+#define CANARD_CAN_FRAME_ERR    (1U << 29)  //error frame
+
+#define CANARD_SOURCE_ID_FROM_ID(x) (x) & (0X7F)
+#define CANARD_SERVICE_NOT_MSG_FROM_ID(x)   (((x) >> 7)  & 0X1)
+#define CANARD_REQUEST_NOT_RESPONSE_FROM_ID(x) (((x) >> 15) & 0X1)
+#define CANARD_DEST_ID_FROM_ID(x)   (((x) >> 8)  & 0X7F)
+#define CANARD_PRIORITY_FROM_ID(x)  (((x) >> 24) & 0X1F)
+#define CANARD_MSG_TYPE_FROM_ID(x)  (((x) >> 8)  & 0XFFFF)
+#define CANARD_SRV_TYPE_FROM_ID(x)  (((x) >> 16)  & 0XFF)
+
+#define TRANSFER_ID_FROM_TAIL_BYTE(x) ((x) & 0X1F)
+
+#define IS_START_OF_TRANSFER(x) (((x) >> 7) & 0X1)
+#define IS_END_OF_TRANSFER(x) (((x) >> 6) & 0X1)
+#define TOGGLE_BIT(x) (((x) >> 5) & 0X1)
+
 
 CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -37,7 +37,6 @@ extern "C" {
 
 CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
-// CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
 CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len);

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -74,6 +74,8 @@ CANARD_INTERNAL int computeForwardDistance(uint8_t a, uint8_t b);
 CANARD_INTERNAL void tidIncrement(uint8_t* transfer_id);
 CANARD_INTERNAL uint64_t canardReleaseStatePayload(CanardInstance* ins, CanardRxState* rxstate);
 CANARD_INTERNAL int canardEnqueueData(CanardInstance* ins, uint32_t can_id, uint8_t* transfer_id, const uint8_t* payload, uint16_t payload_len);
+CANARD_INTERNAL uint16_t crc_add_byte(uint16_t crc_val, uint8_t byte);
+CANARD_INTERNAL uint16_t crc_add(uint16_t crc_val, const uint8_t* bytes, uint16_t len);
 
 /** Inits a memory allocator.
  *

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -2,6 +2,7 @@
 #define CANARD_INTERNALS_H
 
 #include <unistd.h>
+//#include "canard.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,17 +12,21 @@ extern "C" {
 # define CANARD_INTERNAL static
 #endif
 
-/** A memory block used in the memory block allocator. */
-typedef union CanardPoolAllocatorBlock_u
-{
-    char bytes[CANARD_MEM_BLOCK_SIZE];
-    union CanardPoolAllocatorBlock_u* next;
-} CanardPoolAllocatorBlock;
 
-typedef struct
-{
-    CanardPoolAllocatorBlock* free_list;
-} CanardPoolAllocator;
+CANARD_INTERNAL CanardRxState *canardRxStateTraversal(CanardInstance* ins, const CanardCANFrame* frame, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState *canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState *canardAppendRxState(CanardInstance* ins, uint32_t transfer_descriptor);
+CANARD_INTERNAL CanardRxState *canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
+CANARD_INTERNAL void canardPrintStates(CanardInstance* ins);
+CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state, const uint8_t* data, uint8_t data_len);
+CANARD_INTERNAL CanardBufferBlock *canardCreateBufferBlock(CanardPoolAllocator* allocator);
+CANARD_INTERNAL uint8_t canardTransferType(uint32_t id);
+CANARD_INTERNAL uint16_t canardDataType(uint32_t id);
+CANARD_INTERNAL void canardPushTxQueue(CanardInstance* ins, CanardTxQueueItem* item);
+CANARD_INTERNAL bool priorityHigherThan(uint32_t id, uint32_t rhs);
+CANARD_INTERNAL void canardPrintQueue(CanardInstance* ins);
+CANARD_INTERNAL CanardTxQueueItem *canardCreateTxItem(CanardPoolAllocator* allocator);
+CANARD_INTERNAL void cleanCanardRxState(CanardRxState* state);
 
 /** Inits a memory allocator.
  *

--- a/src/canard_internals.h
+++ b/src/canard_internals.h
@@ -62,7 +62,7 @@ CANARD_INTERNAL CanardRxState* canardRxStateTraversal(CanardInstance* ins, uint3
 CANARD_INTERNAL CanardRxState* canardCreateRxState(CanardPoolAllocator* allocator, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState* canardPrependRxState(CanardInstance* ins, uint32_t transfer_descriptor);
 CANARD_INTERNAL CanardRxState* canardFindRxState(CanardRxState* state, uint32_t transfer_descriptor);
-CANARD_INTERNAL void canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state,
+CANARD_INTERNAL int canardBufferBlockPushBytes(CanardPoolAllocator* allocator, CanardRxState* state,
                                                 const uint8_t* data,
                                                 uint8_t data_len);
 CANARD_INTERNAL CanardBufferBlock* canardCreateBufferBlock(CanardPoolAllocator* allocator);

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -298,17 +298,20 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     {
     case CanardTransferTypeResponse:
         printf("reponse\n");
+        break;
     case CanardTransferTypeRequest:
         printf("request\n");
+        break;
     case CanardTransferTypeBroadcast:
         printf("broadcast\n");
+        break;
+    default:
+        break;
     }
     unsigned char payload[transfer->payload_len];
     if (transfer->payload_len > 7)
     {
         CanardBufferBlock* block = transfer->payload_middle;
-        // printf("sizeof payload head: %lu\n",sizeof(transfer->payload_head));
-        // printf("sizeof payload tail: %lu\n",sizeof(transfer->payload_tail));
         int i;
         uint8_t index = 0;
         if (CANARD_RX_PAYLOAD_HEAD_SIZE > 0)
@@ -316,14 +319,12 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
             for (i = 0; i < CANARD_RX_PAYLOAD_HEAD_SIZE; i++, index++)
             {
                 payload[i] = transfer->payload_head[i];
-                // printf("index: %u\n", index);
             }
         }
 
         for (i = 0; index < (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len); i++, index++)
         {
             payload[index] = block->data[i];
-            // printf("index: %u\n", index);
             if (i==CANARD_BUFFER_BLOCK_DATA_SIZE - 1)
             {
                 i = -1;
@@ -331,7 +332,6 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
             }
         }
 
-        // printf("tail:\n");
         int tail_len = transfer->payload_len - (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len);
         for (i = 0; i<(tail_len); i++, index++)
         {
@@ -346,12 +346,8 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
             payload[i] = transfer->payload_head[i];
         }
     }
-    // uint64_t payload_64 = canardReadRxTransferPayload(transfer, 0, 64);
-    // printf("payload:%" PRIx64 "\n", payload_64);
 
     printf("payload:%016" PRIx64 "\n", canardReadRxTransferPayload(transfer, 0, 64));
-    printf("payload:%016" PRIx64 "\n", canardReadRxTransferPayload(transfer, 64, 64));
-    printf("payload:%016" PRIx64 "\n", canardReadRxTransferPayload(transfer, 128, 64));
 
     canardReleaseRxTransferPayload(ins, transfer);
     // do stuff with the data then call canardReleaseRxTransferPayload() if there are blocks (multi-frame transfers)
@@ -400,7 +396,7 @@ void* receiveThread(void* canard_instance)
         // printf("%X\n",CANARD_MSG_TYPE_FROM_ID(r_frame.can_id));
         canard_frame.data_len = r_frame.can_dlc;
         memcpy(canard_frame.data, &r_frame.data, r_frame.can_dlc);
-        printframe(&canard_frame);
+        // printframe(&canard_frame);
         canardHandleRxFrame(canard_instance, &canard_frame, get_monotonic_usec());
     }
 }

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -57,6 +57,7 @@ int can_init(const char* can_iface_name)
 
     (void)memset(&ifr, 0, sizeof(ifr));
     (void)strncpy(ifr.ifr_name, can_iface_name, IFNAMSIZ);
+    ifr.ifr_name[IFNAMSIZ] = '\0';
     const int ioctl_result = ioctl(sock, SIOCGIFINDEX, &ifr);
     if (ioctl_result < 0)
     {
@@ -308,7 +309,8 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     default:
         break;
     }
-    unsigned char payload[transfer->payload_len] = 0;
+    uint8_t payload[transfer->payload_len];
+    memset(payload, 0, sizeof payload);
     if (transfer->payload_len > 7)
     {
         CanardBufferBlock* block = transfer->payload_middle;

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -334,8 +334,15 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     printf("\n");
 }
 
+bool should_accept(const CanardInstance* ins, uint64_t* out_data_type_signature,
+                    uint16_t data_type_id, CanardTransferType transfer_type, uint8_t source_node_id)
+{
+    return true;
+}
+
 // returns true with a probability of probability 
-bool random_drop(double probability) {
+bool random_drop(double probability)
+{
     return rand() <  probability * ((double)RAND_MAX + 1.0);
 }
 
@@ -466,7 +473,7 @@ int main(int argc, char** argv)
     // enum node_health health = HEALTH_OK;
     static CanardInstance canard_instance;
         
-    canardInit(&canard_instance, on_reception);
+    canardInit(&canard_instance, on_reception, should_accept);
     canardSetLocalNodeID(&canard_instance,uavcan_node_id);
     printf("Initialized.\n");
 

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -26,10 +26,10 @@
 
 #define CLEANUP_STALE_TRANSFERS 2000000
 
-#define TIME_TO_SEND_NODE_STATUS 101000
-#define TIME_TO_SEND_AIRSPEED 510000
-#define TIME_TO_SEND_MULTI 200000
-#define TIME_TO_SEND_REQUEST 100000
+#define TIME_TO_SEND_NODE_STATUS 101000000
+#define TIME_TO_SEND_AIRSPEED 51000000000
+#define TIME_TO_SEND_MULTI 1000000
+#define TIME_TO_SEND_REQUEST 1000000000
 static int can_socket = -1;
 
 int can_init(const char* can_iface_name)
@@ -336,7 +336,8 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
 
 bool should_accept(const CanardInstance* ins, uint64_t* out_data_type_signature,
                     uint16_t data_type_id, CanardTransferType transfer_type, uint8_t source_node_id)
-{
+{   
+    *out_data_type_signature = 0x8899AABBCCDDEEFF;
     return true;
 }
 
@@ -426,7 +427,7 @@ void *sendThread(void* canard_instance) {
         {
             if (drop)
             {
-                printf("dropping ");
+                printf("dropping\n");
                 // printframe(transmit_frame);
                 //can_send(transmit_frame->id, transmit_frame->data, transmit_frame->data_len);
             }
@@ -476,7 +477,7 @@ int main(int argc, char** argv)
     canardInit(&canard_instance, on_reception, should_accept);
     canardSetLocalNodeID(&canard_instance,uavcan_node_id);
     printf("Initialized.\n");
-
+    printf("size: %lu\n",sizeof(CanardRxState));
 
     /*
      * Main loop

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -25,10 +25,12 @@
 #include <pthread.h>
 
 #define CLEANUP_STALE_TRANSFERS 2000000
+#define CANARD_AVAILABLE_BLOCKS 32
+
 
 #define TIME_TO_SEND_NODE_STATUS 101000000
 #define TIME_TO_SEND_AIRSPEED 51000000000
-#define TIME_TO_SEND_MULTI 1000000
+#define TIME_TO_SEND_MULTI 100000
 #define TIME_TO_SEND_REQUEST 1000000000
 static int can_socket = -1;
 
@@ -473,8 +475,8 @@ int main(int argc, char** argv)
     //  */
     // enum node_health health = HEALTH_OK;
     static CanardInstance canard_instance;
-        
-    canardInit(&canard_instance, on_reception, should_accept);
+    CanardPoolAllocatorBlock buffer[32];           // pool blocks
+    canardInit(&canard_instance, buffer, sizeof(buffer), on_reception, should_accept);
     canardSetLocalNodeID(&canard_instance,uavcan_node_id);
     printf("Initialized.\n");
 

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -280,9 +280,7 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
             printf("request\n");
         case CanardTransferTypeBroadcast:
             printf("broadcast\n");
-    } 
     }
-    printf("payload len: %u \n", transfer->payload_len);
     unsigned char payload[transfer->payload_len];
     if (transfer->payload_len > 7)
     {
@@ -295,17 +293,13 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     {
         for (i=0; i < CANARD_RX_PAYLOAD_HEAD_SIZE; i++)
         {
-            printf("%02X ",transfer->payload_head[i]);
             payload[i] = transfer->payload_head[i];
         }
         index = i;
     }
-    //canardPrintBlocks(block);
 
     for (i=0; index < (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len); i++, index++)
     {
-        //printf("index: %i\n",i);
-        printf("%02X ",block->data[i]);
         payload[index] = block->data[i];
         if(i==CANARD_BUFFER_BLOCK_DATA_SIZE-1)
         {
@@ -318,10 +312,8 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     int tail_len = transfer->payload_len - (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len);
     for (i=0; i<(tail_len);i++, index++)
     {
-        printf("%02X ",transfer->payload_tail[i]);
         payload[index] = transfer->payload_tail[i];
     }
-    printf("\n");
     
     }
     else
@@ -329,10 +321,8 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
         uint8_t i;
         for (i = 0; i<transfer->payload_len; i++)
         {
-            printf("%02X ", transfer->payload_head[i]);
             payload[i] = transfer->payload_head[i];
         }
-        printf("\n");
     }
     canardReleaseRxTransferPayload(ins, transfer);
     //do stuff with the data then call canardReleaseRxTransferPayload() if there are blocks (multi-frame transfers)
@@ -430,7 +420,7 @@ void *sendThread(void* canard_instance) {
             if (drop)
             {
                 printf("dropping ");
-                printframe(transmit_frame);
+                // printframe(transmit_frame);
                 //can_send(transmit_frame->id, transmit_frame->data, transmit_frame->data_len);
             }
             else

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -475,7 +475,7 @@ int main(int argc, char** argv)
     //  */
     // enum node_health health = HEALTH_OK;
     static CanardInstance canard_instance;
-    CanardPoolAllocatorBlock buffer[32];           // pool blocks
+    static CanardPoolAllocatorBlock buffer[32];           // pool blocks
     canardInit(&canard_instance, buffer, sizeof(buffer), on_reception, should_accept);
     canardSetLocalNodeID(&canard_instance,uavcan_node_id);
     printf("Initialized.\n");

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -1,0 +1,470 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include "canard.h"
+// #include "canard_debug.h"
+/*
+ * This part is specific for Linux. It can be replaced for use on other platforms.
+ * Note that under Linux this source must be linked with librt (for GCC add -lrt)
+ */
+#include <sys/time.h>
+#include <net/if.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <linux/can.h>
+#include <linux/can/raw.h>
+#include <time.h>
+
+#include <inttypes.h>
+#include <pthread.h>
+
+#define CLEANUP_STALE_TRANSFERS 2000000
+
+#define TIME_TO_SEND_NODE_STATUS 101000
+#define TIME_TO_SEND_AIRSPEED 510000
+#define TIME_TO_SEND_MULTI 200000
+#define TIME_TO_SEND_REQUEST 100000
+static int can_socket = -1;
+
+int can_init(const char* can_iface_name)
+{
+    // Open the SocketCAN socket
+    const int sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (sock < 0)
+    {
+        return -1;
+    }
+
+    // Resolve the iface index
+    struct ifreq ifr;
+    (void)memset(&ifr, 0, sizeof(ifr));
+    (void)strncpy(ifr.ifr_name, can_iface_name, IFNAMSIZ);
+    const int ioctl_result = ioctl(sock, SIOCGIFINDEX, &ifr);
+    if (ioctl_result < 0)
+    {
+        return -1;
+    }
+
+    // Assign the iface
+    struct sockaddr_can addr;
+    (void)memset(&addr, 0, sizeof(addr));
+    addr.can_family  = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+
+    // Bind the socket to the iface
+    const int bind_result = bind(sock, (struct sockaddr*)&addr, sizeof(addr));
+    if (bind_result < 0)
+    {
+        return -1;
+    }
+
+    can_socket = sock;
+    return 0;
+}
+static uint8_t uavcan_node_id;
+
+int can_send(uint32_t extended_can_id, const uint8_t* frame_data, uint8_t frame_data_len)
+{
+    if (frame_data_len > 8 || frame_data == NULL)
+    {
+        return -1;
+    }
+
+    struct can_frame frame;
+    frame.can_id  = extended_can_id | CAN_EFF_FLAG;
+    frame.can_dlc = frame_data_len;
+    memcpy(frame.data, frame_data, frame_data_len);
+
+    return write(can_socket, &frame, sizeof(struct can_frame));
+}
+
+uint64_t get_monotonic_usec(void)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+    {
+        return 0;
+    }
+    return (uint64_t)ts.tv_sec * 1000000ULL + (uint64_t)ts.tv_nsec / 1000UL;
+}
+
+/// Arbitrary priority values
+static const uint8_t PRIORITY_HIGHEST = 0;
+static const uint8_t PRIORITY_HIGH    = 8;
+static const uint8_t PRIORITY_MEDIUM  = 16;
+static const uint8_t PRIORITY_LOW     = 24;
+static const uint8_t PRIORITY_LOWEST  = 31;
+
+/// Defined for the standard data type uavcan.protocol.NodeStatus
+enum node_health
+{
+    HEALTH_OK       = 0,
+    HEALTH_WARNING  = 1,
+    HEALTH_ERROR    = 2,
+    HEALTH_CRITICAL = 3
+};
+
+/// Defined for the standard data type uavcan.protocol.NodeStatus
+enum node_mode
+{
+    MODE_OPERATIONAL     = 0,
+    MODE_INITIALIZATION  = 1,
+    MODE_MAINTENANCE     = 2,
+    MODE_SOFTWARE_UPDATE = 3,
+    MODE_OFFLINE         = 7
+};
+/// Standard data type: uavcan.protocol.NodeStatus
+int publish_node_status(CanardInstance* ins, enum node_health health, enum node_mode mode, uint16_t vendor_specific_status_code)
+{
+    static uint64_t startup_timestamp_usec;
+    if (startup_timestamp_usec == 0)
+    {
+        startup_timestamp_usec = get_monotonic_usec();
+    }
+
+    uint8_t payload[7];
+
+    // Uptime in seconds
+    const uint32_t uptime_sec = (get_monotonic_usec() - startup_timestamp_usec) / 1000000ULL;
+    payload[0] = (uptime_sec >> 0)  & 0xFF;
+    payload[1] = (uptime_sec >> 8)  & 0xFF;
+    payload[2] = (uptime_sec >> 16) & 0xFF;
+    payload[3] = (uptime_sec >> 24) & 0xFF;
+
+    // Health and mode
+    payload[4] = ((uint8_t)health << 6) | ((uint8_t)mode << 3);
+
+    // Vendor-specific status code
+    payload[5] = (vendor_specific_status_code >> 0) & 0xFF;
+    payload[6] = (vendor_specific_status_code >> 8) & 0xFF;
+
+    static const uint16_t data_type_id = 341;
+    static uint8_t transfer_id;
+    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_LOW, payload, sizeof(payload));
+}
+/*
+ * Float16 support
+ */
+uint16_t make_float16(float value)
+{
+    union fp32
+    {
+        uint32_t u;
+        float f;
+    };
+
+    const union fp32 f32infty = { 255U << 23 };
+    const union fp32 f16infty = { 31U << 23 };
+    const union fp32 magic = { 15U << 23 };
+    const uint32_t sign_mask = 0x80000000U;
+    const uint32_t round_mask = ~0xFFFU;
+
+    union fp32 in;
+    uint16_t out = 0;
+
+    in.f = value;
+
+    uint32_t sign = in.u & sign_mask;
+    in.u ^= sign;
+
+    if (in.u >= f32infty.u)
+    {
+        out = (in.u > f32infty.u) ? 0x7FFFU : 0x7C00U;
+    }
+    else
+    {
+        in.u &= round_mask;
+        in.f *= magic.f;
+        in.u -= round_mask;
+        if (in.u > f16infty.u)
+        {
+            in.u = f16infty.u;
+        }
+        out = (uint16_t)(in.u >> 13);
+    }
+
+    out |= (uint16_t)(sign >> 16);
+
+    return out;
+}
+/// Standard data type: uavcan.equipment.air_data.TrueAirspeed
+int publish_true_airspeed(CanardInstance* ins, float mean, float variance)
+{
+    const uint16_t f16_mean     = make_float16(mean);
+    const uint16_t f16_variance = make_float16(variance);
+
+    uint8_t payload[4];
+    payload[0] = (f16_mean >> 0) & 0xFF;
+    payload[1] = (f16_mean >> 8) & 0xFF;
+    payload[2] = (f16_variance >> 0) & 0xFF;
+    payload[3] = (f16_variance >> 8) & 0xFF;
+
+    static const uint16_t data_type_id = 1020;
+    static uint8_t transfer_id;
+    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_MEDIUM, payload, sizeof(payload));
+}
+
+/// Standard data type: uavcan.equipment.multi
+int publish_multi(CanardInstance* ins)
+{
+    static int len = 80;
+    uint8_t payload[len];
+    uint8_t i;
+    for (i=0; i<len; i++)
+    {
+        payload[i] = i+1;
+    }
+    static const uint16_t data_type_id = 420;
+    static uint8_t transfer_id;
+    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_HIGH, payload, sizeof(payload));
+}
+
+int publish_request(CanardInstance* ins)
+{
+    static int len = 43;
+    uint8_t payload[len];
+    uint8_t i;
+    for (i=0; i<len; i++)
+    {
+        payload[i] = i+3;
+    }
+    uint8_t dest_id = 33;
+    static const uint16_t data_type_id = 15;
+    static uint8_t transfer_id;
+    return canardRequestOrRespond(ins, dest_id, data_type_id, &transfer_id, PRIORITY_LOW, CanardRequest, payload, sizeof(payload));
+}
+
+int compute_true_airspeed(float* out_airspeed, float* out_variance)
+{
+    *out_airspeed = 1.2345F; // This is a stub.
+    *out_variance = 0.0F;    // By convention, zero represents unknown error variance.
+    return 0;
+}
+
+// Standard data type: uavcan.equipment.
+
+void printframe(const CanardCANFrame* frame)
+{
+    printf("%X ",frame->id);
+    printf("[%u] ",frame->data_len);
+    int i;
+    for(i = 0; i < frame->data_len; i++)
+    {
+        printf(" %u ", frame->data[i]);
+    }
+    printf("\n");
+}
+
+void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
+{
+    // printf("\n");
+    printf("transfer type: ");
+    switch(transfer->transfer_type) {
+        case CanardTransferTypeResponse:
+            printf("reponse\n");
+        case CanardTransferTypeRequest:
+            printf("request\n");
+        case CanardTransferTypeBroadcast:
+            printf("broadcast\n");
+    }
+    printf("payload len: %u \n", transfer->payload_len);
+    if (transfer->payload_len > 7)
+    {
+    CanardBufferBlock* block = transfer->payload_middle;
+    // printf("sizeof payload head: %lu\n",sizeof(transfer->payload_head));
+    // printf("sizeof payload tail: %lu\n",sizeof(transfer->payload_tail));
+    int i, index;
+
+    for (i=0; i < CANARD_RX_PAYLOAD_HEAD_SIZE; i++)
+    {
+        printf("%u ",transfer->payload_head[i]);
+    }
+
+    //canardPrintBlocks(block);
+
+    for (index=i+1, i=0; index < (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len); i++, index++)
+    {
+        //printf("index: %i\n",i);
+        printf("%u ",block->data[i]);
+        if(i==CANARD_BUFFER_BLOCK_DATA_SIZE-1)
+        {
+            i = -1;
+            block = block->next;
+        }
+    }
+
+    //printf("tail:\n");
+    int tail_len = transfer->payload_len - (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len);
+    for (i=0; i<(tail_len);i++)
+    {
+        printf("%u ",transfer->payload_tail[i]);
+    }
+    printf("\n");
+    
+    }
+    else
+    {
+        uint8_t i;
+        for (i = 0; i<transfer->payload_len; i++)
+        {
+            printf("%02X ", transfer->payload_head[i]);
+        }
+        printf("\n");
+    }
+    canardReleaseRxTransferPayload(ins, transfer);
+    //do stuff with the data then call canardReleaseRxTransferPayload() if there are blocks (multi-frame transfers)
+}
+
+// returns true with a probability of probability 
+bool random_drop(double probability) {
+    return rand() <  probability * ((double)RAND_MAX + 1.0);
+}
+
+void *receiveThread(void* canard_instance)
+{
+    struct can_frame r_frame;
+    CanardCANFrame canard_frame;
+    // CanardCANFrame* transmit_frame;
+    int nbytes = 0;
+    while(1)
+    {
+        nbytes = read(can_socket, &r_frame, sizeof(struct can_frame));
+        if (nbytes < 0)
+        {
+            perror("can raw socket read");
+            return NULL;
+        }
+        else if (nbytes == 0)
+        {
+            printf("problem");
+        }
+        canard_frame.id = r_frame.can_id;
+        //printf("%X\n",CANARD_MSG_TYPE_FROM_ID(r_frame.can_id));
+        canard_frame.data_len = r_frame.can_dlc;
+        memcpy(canard_frame.data, &r_frame.data, r_frame.can_dlc);
+        //printframe(&canard_frame);
+        canardHandleRxFrame(canard_instance, &canard_frame, get_monotonic_usec());
+    }
+}
+
+void *sendThread(void* canard_instance) {
+    enum node_health health = HEALTH_OK;
+    uint64_t last_node_status = 0;
+    uint64_t last_multi = 0;
+    uint64_t last_clean = 0;
+    uint64_t last_airspeed = 0;
+    uint64_t last_request = 0;
+    bool drop = false;
+    while(1)
+    {
+        if ((get_monotonic_usec() - last_node_status) > TIME_TO_SEND_NODE_STATUS)
+        {
+            const uint16_t vendor_specific_status_code = rand(); // Can be used to report vendor-specific status info
+            publish_node_status(canard_instance, health, MODE_OPERATIONAL, vendor_specific_status_code);
+            last_node_status = get_monotonic_usec();
+        }
+
+        if ((get_monotonic_usec() - last_airspeed) > TIME_TO_SEND_AIRSPEED)
+        {
+            float airspeed = 0.0F;
+            float airspeed_variance = 0.0F;
+            const int airspeed_computation_result = compute_true_airspeed(&airspeed, &airspeed_variance);
+
+            if (airspeed_computation_result == 0)
+            {
+                const int publication_result = publish_true_airspeed(canard_instance, airspeed, airspeed_variance);
+                health = (publication_result < 0) ? HEALTH_ERROR : HEALTH_OK;
+            }
+            else
+            {
+                health = HEALTH_ERROR;
+            }
+            last_airspeed = get_monotonic_usec();
+        }
+        if ((get_monotonic_usec() - last_multi) > TIME_TO_SEND_MULTI)
+        {
+            publish_multi(canard_instance);
+            last_multi = get_monotonic_usec();
+        }
+        if ((get_monotonic_usec() - last_request) > TIME_TO_SEND_REQUEST) {
+            publish_request(canard_instance);
+            last_request = get_monotonic_usec();
+        }
+        if ((get_monotonic_usec() - last_clean) > CLEANUP_STALE_TRANSFERS)
+        {
+            canardCleanupStaleTransfers(canard_instance, CLEANUP_STALE_TRANSFERS, get_monotonic_usec());
+            last_clean = get_monotonic_usec();
+        }
+        const CanardCANFrame *transmit_frame = canardPeekTxQueue(canard_instance);
+        if (transmit_frame != NULL)
+        {
+            if (drop)
+            {
+                printf("dropping ");
+                printframe(transmit_frame);
+                //can_send(transmit_frame->id, transmit_frame->data, transmit_frame->data_len);
+            }
+            else
+            {
+                //printf("keeping\n");
+                //printframe(transmit_frame);
+                can_send(transmit_frame->id, transmit_frame->data, transmit_frame->data_len);
+            }
+            canardPopTxQueue(canard_instance);
+            drop = random_drop(.0);
+        }
+    }
+}
+
+int main(int argc, char** argv)
+{
+    srand(time(NULL));
+    /*
+     * Node initialization
+     */
+    if (argc < 3)
+    {
+        puts("Args: <self-node-id> <can-iface-name>");
+        return 1;
+    }
+
+    uavcan_node_id = (uint8_t)atoi(argv[1]);
+    if (uavcan_node_id < 1 || uavcan_node_id > 127)
+    {
+        printf("%i is not a valid node ID\n", (int)uavcan_node_id);
+        return 1;
+    }
+
+    if (can_init(argv[2]) < 0)
+    {
+        printf("Failed to open iface %s\n", argv[2]);
+        return 1;
+    }
+
+    // /*
+    //  * Main loop
+    //  */
+    // enum node_health health = HEALTH_OK;
+    static CanardInstance canard_instance;
+        
+    canardInit(&canard_instance, on_reception);
+    canardSetLocalNodeID(&canard_instance,uavcan_node_id);
+    printf("Initialized.\n");
+
+
+    /*
+     * Main loop
+     */
+
+    pthread_t tid1, tid2;
+    pthread_create(&tid1, NULL, receiveThread, &canard_instance);
+    pthread_create(&tid2, NULL, sendThread, &canard_instance);
+    pthread_join(tid1, NULL);
+    pthread_join(tid2,NULL);
+}

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -398,7 +398,7 @@ void *sendThread(void* canard_instance) {
         }
         if ((get_monotonic_usec() - last_clean) > CLEANUP_STALE_TRANSFERS)
         {
-            canardCleanupStaleTransfers(canard_instance, CLEANUP_STALE_TRANSFERS, get_monotonic_usec());
+            canardCleanupStaleTransfers(canard_instance, get_monotonic_usec());
             last_clean = get_monotonic_usec();
         }
         const CanardCANFrame *transmit_frame = canardPeekTxQueue(canard_instance);

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -272,26 +272,33 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
             printf("request\n");
         case CanardTransferTypeBroadcast:
             printf("broadcast\n");
+    } 
     }
     printf("payload len: %u \n", transfer->payload_len);
+    unsigned char payload[transfer->payload_len];
     if (transfer->payload_len > 7)
     {
     CanardBufferBlock* block = transfer->payload_middle;
     // printf("sizeof payload head: %lu\n",sizeof(transfer->payload_head));
     // printf("sizeof payload tail: %lu\n",sizeof(transfer->payload_tail));
-    int i, index;
+    int i, index = 0;
 
-    for (i=0; i < CANARD_RX_PAYLOAD_HEAD_SIZE; i++)
+    if(CANARD_RX_PAYLOAD_HEAD_SIZE > 0)
     {
-        printf("%u ",transfer->payload_head[i]);
+        for (i=0; i < CANARD_RX_PAYLOAD_HEAD_SIZE; i++)
+        {
+            printf("%02X ",transfer->payload_head[i]);
+            payload[i] = transfer->payload_head[i];
+        }
+        index = i;
     }
-
     //canardPrintBlocks(block);
 
-    for (index=i+1, i=0; index < (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len); i++, index++)
+    for (i=0; index < (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len); i++, index++)
     {
         //printf("index: %i\n",i);
-        printf("%u ",block->data[i]);
+        printf("%02X ",block->data[i]);
+        payload[index] = block->data[i];
         if(i==CANARD_BUFFER_BLOCK_DATA_SIZE-1)
         {
             i = -1;
@@ -301,9 +308,10 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
 
     //printf("tail:\n");
     int tail_len = transfer->payload_len - (CANARD_RX_PAYLOAD_HEAD_SIZE + transfer->middle_len);
-    for (i=0; i<(tail_len);i++)
+    for (i=0; i<(tail_len);i++, index++)
     {
-        printf("%u ",transfer->payload_tail[i]);
+        printf("%02X ",transfer->payload_tail[i]);
+        payload[index] = transfer->payload_tail[i];
     }
     printf("\n");
     
@@ -314,11 +322,18 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
         for (i = 0; i<transfer->payload_len; i++)
         {
             printf("%02X ", transfer->payload_head[i]);
+            payload[i] = transfer->payload_head[i];
         }
         printf("\n");
     }
     canardReleaseRxTransferPayload(ins, transfer);
     //do stuff with the data then call canardReleaseRxTransferPayload() if there are blocks (multi-frame transfers)
+
+    int i;
+    for (i=0;i<sizeof(payload);i++) {
+        printf("%02X ", payload[i]);
+    }
+    printf("\n");
 }
 
 // returns true with a probability of probability 

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -477,7 +477,6 @@ int main(int argc, char** argv)
     canardInit(&canard_instance, on_reception, should_accept);
     canardSetLocalNodeID(&canard_instance,uavcan_node_id);
     printf("Initialized.\n");
-    printf("size: %lu\n",sizeof(CanardRxState));
 
     /*
      * Main loop

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -308,7 +308,7 @@ void on_reception(CanardInstance* ins, CanardRxTransfer* transfer)
     default:
         break;
     }
-    unsigned char payload[transfer->payload_len];
+    unsigned char payload[transfer->payload_len] = 0;
     if (transfer->payload_len > 7)
     {
         CanardBufferBlock* block = transfer->payload_middle;

--- a/src/canard_test.c
+++ b/src/canard_test.c
@@ -146,7 +146,9 @@ int publish_node_status(CanardInstance* ins, enum node_health health, enum node_
 
     static const uint16_t data_type_id = 341;
     static uint8_t transfer_id;
-    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_LOW, payload, sizeof(payload));
+    uint64_t data_type_signature = 0x8899AABBCCDDEEFF;
+    return canardBroadcast(ins, data_type_signature, 
+        data_type_id, &transfer_id, PRIORITY_LOW, payload, sizeof(payload));
 }
 /*
  * Float16 support
@@ -207,7 +209,9 @@ int publish_true_airspeed(CanardInstance* ins, float mean, float variance)
 
     static const uint16_t data_type_id = 1020;
     static uint8_t transfer_id;
-    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_MEDIUM, payload, sizeof(payload));
+    uint64_t data_type_signature = 0x8899AABBCCDDEEFF;
+    return canardBroadcast(ins, data_type_signature, 
+        data_type_id, &transfer_id, PRIORITY_MEDIUM, payload, sizeof(payload));
 }
 
 /// Standard data type: uavcan.equipment.multi
@@ -222,7 +226,9 @@ int publish_multi(CanardInstance* ins)
     }
     static const uint16_t data_type_id = 420;
     static uint8_t transfer_id;
-    return canardBroadcast(ins, data_type_id, &transfer_id, PRIORITY_HIGH, payload, sizeof(payload));
+    uint64_t data_type_signature = 0x8899AABBCCDDEEFF;
+    return canardBroadcast(ins, data_type_signature, 
+        data_type_id, &transfer_id, PRIORITY_HIGH, payload, sizeof(payload));
 }
 
 int publish_request(CanardInstance* ins)
@@ -237,7 +243,9 @@ int publish_request(CanardInstance* ins)
     uint8_t dest_id = 33;
     static const uint16_t data_type_id = 15;
     static uint8_t transfer_id;
-    return canardRequestOrRespond(ins, dest_id, data_type_id, &transfer_id, PRIORITY_LOW, CanardRequest, payload, sizeof(payload));
+    uint64_t data_type_signature = 0x8899AABBCCDDEEFF;
+    return canardRequestOrRespond(ins, dest_id, data_type_signature, 
+        data_type_id, &transfer_id, PRIORITY_LOW, CanardRequest, payload, sizeof(payload));
 }
 
 int compute_true_airspeed(float* out_airspeed, float* out_variance)

--- a/src/crc_test.c
+++ b/src/crc_test.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdint.h>
+/**
+ * CRC-16-CCITT
+ * Initial value: 0xFFFF
+ * Poly: 0x1021
+ * Reverse: no
+ * Output xor: 0
+ *
+ * import crcmod
+ * crc = crcmod.predefined.Crc('crc-ccitt-false')
+ * crc.update('123456789')
+ * crc.hexdigest()
+ * '29B1'
+ */
+
+uint16_t crc_add_byte(uint16_t crc_running_val, uint8_t byte)
+{
+    crc_running_val ^= (uint16_t)((uint16_t)(byte) << 8);
+    int j;
+    for (j=0; j<8; j++)
+    {
+        if (crc_running_val & 0x8000U)
+        {
+            crc_running_val = (uint16_t)((uint16_t)(crc_running_val << 1) ^ 0x1021U);
+        }
+        else
+        {
+            crc_running_val = (uint16_t)(crc_running_val << 1);
+        }
+    }
+    return crc_running_val;
+}
+
+uint16_t crc_add(uint16_t crc_running_val, const uint8_t* bytes, uint16_t len)
+{
+    while (len--)
+    {
+        crc_running_val = crc_add_byte(crc_running_val,*bytes++);
+    }
+    return crc_running_val;
+}
+
+uint16_t crc_reset(void)
+{
+
+    return 0XFFFFU;
+}
+
+
+int main(int argc, char** argv)
+{
+    uint16_t crc_running_val = crc_reset();
+    crc_running_val = crc_add_byte(crc_running_val,'1');
+    crc_running_val = crc_add_byte(crc_running_val,'2');
+    crc_running_val = crc_add_byte(crc_running_val,'3');
+    printf("%X \n", crc_running_val);
+
+    crc_running_val = crc_add(crc_running_val, "456789", 6);
+    printf("%X \n", crc_running_val);
+    crc_running_val = crc_reset();
+}


### PR DESCRIPTION
Included is my current working version of libcanard. canardReadRxTransferPayload is the only missing function right now. Recent updates to the design document have also not been implemented (ftp://pkir.net/libcanard.diff). canard_test.c, based on simple_sensor_node is what I've been using to test the library. It sends 3 data types on the can interface. There's also a function, random_drop(x), called on the bottom of the send thread that will randomly drop a frame. Set that to the probability you want frames dropped, 0 if you dont want anything dropped. Right now canard_test just prints out the data received from the library.

To do:
implement crc checking
ignore incomplete transfers (probably has to do with the above)

ask any questions!