### PR TITLE
Build in 32bit mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
   apt:
     packages:
     - libgtest-dev
+    - libc6-dev-i386
+    - g++-multilib
+    - libstdc++6-4.6-dev:i386
 
 env:
     - CFLAGS="-Werror" CXXFLAGS="-Werror"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,8 @@ find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 include_directories(../src)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -Wextra")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -Wextra -m32")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -m32")
 
 # Expose internal API for unit testing
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCANARD_INTERNAL=''")


### PR DESCRIPTION
By design libcanard only runs on 32 bit platforms. This PR tells the compiler to build in 32 bit mode.