### PR TITLE
Fix for sending of 0-length messages

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -128,7 +128,7 @@ int canardBroadcast(CanardInstance* ins,
                     const void* payload,
                     uint16_t payload_len)
 {
-    if (payload == NULL)
+    if (payload == NULL && payload_len > 0)
     {
         return -CANARD_ERROR_INVALID_ARGUMENT;
     }
@@ -187,7 +187,7 @@ int canardRequestOrRespond(CanardInstance* ins,
                            const void* payload,
                            uint16_t payload_len)
 {
-    if (payload == NULL)
+    if (payload == NULL && payload_len > 0)
     {
         return -CANARD_ERROR_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
In current master version of library if NULL will be provided as payload, message will not be sent even if payload length is 0.
Additional check for payload length fixes this bug.