### PR TITLE
Allocation failure checks

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -1227,6 +1227,12 @@ CANARD_INTERNAL int bufferBlockPushBytes(CanardPoolAllocator* allocator,
     if (state->buffer_blocks == NULL)
     {
         state->buffer_blocks = createBufferBlock(allocator);
+
+        if (state->buffer_blocks == NULL)
+        {
+            return -CANARD_ERROR_OUT_OF_MEMORY;
+        }
+
         block = state->buffer_blocks;
         index_at_nth_block = 0;
     }


### PR DESCRIPTION
I noticed allocator overflows caused hard fault errors during heavy CAN bus usage, caused by missing null checks after allocation requests.

I also validated that now, the entire call hierarchy for allocateBlock checks for allocation failures to avoid null pointer dereferencing.