### PR TITLE
Extended the library API with a new function canardGetUserReference()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # CMake build directory
 build/
+cmake-build-*/
 
 # IDE and tools
 .idea

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -325,6 +325,7 @@ typedef struct
  * - Local node ID
  * - Memory pool and the associated state variables
  * - List of RX state objects
+ * - An optional user-provided untyped pointer to user-specific data
  */
 struct CanardInstance;
 
@@ -336,7 +337,8 @@ void canardInit(CanardInstance* out_ins,
                 void* mem_arena,
                 size_t mem_arena_size,
                 CanardOnTransferReception on_reception,
-                CanardShouldAcceptTransfer should_accept);
+                CanardShouldAcceptTransfer should_accept,
+                void* user_reference);
 
 /**
  * Assigns a new node ID value to the current node.

--- a/canard.c
+++ b/canard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 UAVCAN Team
+ * Copyright (c) 2016-2017 UAVCAN Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/canard.c
+++ b/canard.c
@@ -72,8 +72,11 @@ void canardInit(CanardInstance* out_ins,
                 void* mem_arena,
                 size_t mem_arena_size,
                 CanardOnTransferReception on_reception,
-                CanardShouldAcceptTransfer should_accept)
+                CanardShouldAcceptTransfer should_accept,
+                void* user_reference)
 {
+    CANARD_ASSERT(out_ins != NULL);
+
     /*
      * Checking memory layout.
      * This condition is supposed to be true for all 32-bit and smaller platforms.
@@ -89,6 +92,7 @@ void canardInit(CanardInstance* out_ins,
     out_ins->should_accept = should_accept;
     out_ins->rx_states = NULL;
     out_ins->tx_queue = NULL;
+    out_ins->user_reference = user_reference;
 
     size_t pool_capacity = mem_arena_size / CANARD_MEM_BLOCK_SIZE;
     if (pool_capacity > 0xFFFFU)
@@ -97,6 +101,12 @@ void canardInit(CanardInstance* out_ins,
     }
 
     initPoolAllocator(&out_ins->allocator, mem_arena, (uint16_t)pool_capacity);
+}
+
+void* canardGetUserReference(CanardInstance* ins)
+{
+    CANARD_ASSERT(ins != NULL);
+    return ins->user_reference;
 }
 
 void canardSetLocalNodeID(CanardInstance* ins, uint8_t self_node_id)

--- a/canard.h
+++ b/canard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 UAVCAN Team
+ * Copyright (c) 2016-2017 UAVCAN Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/canard.h
+++ b/canard.h
@@ -233,6 +233,8 @@ struct CanardInstance
 
     CanardRxState* rx_states;                       ///< RX transfer states
     CanardTxQueueItem* tx_queue;                    ///< TX frames awaiting transmission
+
+    void* user_reference;                           ///< User pointer that can link this instance with other objects
 };
 
 /**
@@ -298,7 +300,15 @@ void canardInit(CanardInstance* out_ins,                    ///< Uninitialized l
                 void* mem_arena,                            ///< Raw memory chunk used for dynamic allocation
                 size_t mem_arena_size,                      ///< Size of the above, in bytes
                 CanardOnTransferReception on_reception,     ///< Callback, see CanardOnTransferReception
-                CanardShouldAcceptTransfer should_accept);  ///< Callback, see CanardShouldAcceptTransfer
+                CanardShouldAcceptTransfer should_accept,   ///< Callback, see CanardShouldAcceptTransfer
+                void* user_reference);                      ///< Optional pointer for user's convenience, can be NULL
+
+/**
+ * Returns the value of the user pointer.
+ * The user pointer is configured once during initialization.
+ * It can be used to store references to any user-specific data, or to link the instance object with C++ objects.
+ */
+void* canardGetUserReference(CanardInstance* ins);
 
 /**
  * Assigns a new node ID value to the current node.

--- a/canard_internals.h
+++ b/canard_internals.h
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2016 UAVCAN Team
+ * Copyright (c) 2016-2017 UAVCAN Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016 UAVCAN Team
+# Copyright (c) 2016-2017 UAVCAN Team
 #
 
 cmake_minimum_required(VERSION 2.8)

--- a/tests/demo.c
+++ b/tests/demo.c
@@ -424,7 +424,7 @@ int main(int argc, char** argv)
     /*
      * Initializing the Libcanard instance.
      */
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer);
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, NULL);
 
     /*
      * Performing the dynamic node ID allocation procedure.

--- a/tests/test_init.cpp
+++ b/tests/test_init.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 UAVCAN Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Contributors: https://github.com/UAVCAN/libcanard/contributors
+ */
+
+#include <gtest/gtest.h>
+#include "canard.h"
+
+static bool shouldAcceptTransferMock(const CanardInstance*,
+                                     uint64_t*,
+                                     uint16_t,
+                                     CanardTransferType,
+                                     uint8_t)
+{
+    return false;
+}
+
+static void onTransferReceptionMock(CanardInstance*,
+                                    CanardRxTransfer*)
+{
+}
+
+
+TEST(Init, UserReference)
+{
+    std::uint8_t memory_arena[1024];
+
+    ::CanardInstance ins;
+    canardInit(&ins,
+               memory_arena,
+               sizeof(memory_arena),
+               &onTransferReceptionMock,
+               &shouldAcceptTransferMock,
+               reinterpret_cast<void*>(12345));
+
+    ASSERT_EQ(12345, reinterpret_cast<int>(canardGetUserReference(&ins)));
+}


### PR DESCRIPTION
The new function `canardGetUserReference()` will be useful when the library instance requires integration into larger data structures, such as C++ objects. Having a user-specific reference will enable the user code to route the callbacks correctly. Example:

```c++
static void callbackFromTheLibraryTrampoline(CanardInstance* const ins, Stuff stuff)
{
    assert(ins->user_reference != nullptr);
    reinterpret_cast<MyClass*>(ins->user_reference)->callbackFromTheLibrary(stuff);
}
```