### PR TITLE
Fix new NuttX CAN Bus header location

### DIFF
--- a/drivers/nuttx/canard_nuttx.c
+++ b/drivers/nuttx/canard_nuttx.c
@@ -10,7 +10,7 @@
 #include <poll.h>
 #include <string.h>
 #include <unistd.h>
-#include <nuttx/drivers/can.h>
+#include <nuttx/can/can.h>
 
 int canardNuttXInit(CanardNuttXInstance* out_ins, const char* can_iface_name)
 {


### PR DESCRIPTION
Hi Pavel,
This patch is needed to get libcanard working on NuttX.