### PR TITLE
Removed all native integral types in favor of stdint in order to improve portability and compliance with high-integrity coding standards

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -58,11 +58,6 @@
 #define IS_END_OF_TRANSFER(x)                       ((bool)(((uint32_t)(x) >> 6U) & 0x1U))
 #define TOGGLE_BIT(x)                               ((bool)(((uint32_t)(x) >> 5U) & 0x1U))
 
-// This is needed to prevent usage of plain integral types (MISRA 3-9-2)
-#define int
-#define unsigned
-#define long
-
 
 struct CanardTxQueueItem
 {

--- a/canard.c
+++ b/canard.c
@@ -54,9 +54,14 @@
 #define TRANSFER_ID_FROM_TAIL_BYTE(x)               ((uint8_t)((x) & 0x1FU))
 
 // The extra cast to unsigned is needed to squelch warnings from clang-tidy
-#define IS_START_OF_TRANSFER(x)                     ((bool)(((unsigned)(x) >> 7U) & 0x1U))
-#define IS_END_OF_TRANSFER(x)                       ((bool)(((unsigned)(x) >> 6U) & 0x1U))
-#define TOGGLE_BIT(x)                               ((bool)(((unsigned)(x) >> 5U) & 0x1U))
+#define IS_START_OF_TRANSFER(x)                     ((bool)(((uint32_t)(x) >> 7U) & 0x1U))
+#define IS_END_OF_TRANSFER(x)                       ((bool)(((uint32_t)(x) >> 6U) & 0x1U))
+#define TOGGLE_BIT(x)                               ((bool)(((uint32_t)(x) >> 5U) & 0x1U))
+
+// This is needed to prevent usage of plain integral types (MISRA 3-9-2)
+#define int
+#define unsigned
+#define long
 
 
 struct CanardTxQueueItem
@@ -131,13 +136,13 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins)
     return ins->node_id;
 }
 
-int canardBroadcast(CanardInstance* ins,
-                    uint64_t data_type_signature,
-                    uint16_t data_type_id,
-                    uint8_t* inout_transfer_id,
-                    uint8_t priority,
-                    const void* payload,
-                    uint16_t payload_len)
+int16_t canardBroadcast(CanardInstance* ins,
+                        uint64_t data_type_signature,
+                        uint16_t data_type_id,
+                        uint8_t* inout_transfer_id,
+                        uint8_t priority,
+                        const void* payload,
+                        uint16_t payload_len)
 {
     if (payload == NULL && payload_len > 0)
     {
@@ -181,22 +186,22 @@ int canardBroadcast(CanardInstance* ins,
         }
     }
 
-    const int result = enqueueTxFrames(ins, can_id, inout_transfer_id, crc, payload, payload_len);
+    const int16_t result = enqueueTxFrames(ins, can_id, inout_transfer_id, crc, payload, payload_len);
 
     incrementTransferID(inout_transfer_id);
 
     return result;
 }
 
-int canardRequestOrRespond(CanardInstance* ins,
-                           uint8_t destination_node_id,
-                           uint64_t data_type_signature,
-                           uint8_t data_type_id,
-                           uint8_t* inout_transfer_id,
-                           uint8_t priority,
-                           CanardRequestResponse kind,
-                           const void* payload,
-                           uint16_t payload_len)
+int16_t canardRequestOrRespond(CanardInstance* ins,
+                               uint8_t destination_node_id,
+                               uint64_t data_type_signature,
+                               uint8_t data_type_id,
+                               uint8_t* inout_transfer_id,
+                               uint8_t priority,
+                               CanardRequestResponse kind,
+                               const void* payload,
+                               uint16_t payload_len)
 {
     if (payload == NULL && payload_len > 0)
     {
@@ -222,7 +227,7 @@ int canardRequestOrRespond(CanardInstance* ins,
         crc = crcAdd(crc, payload, payload_len);
     }
 
-    const int result = enqueueTxFrames(ins, can_id, inout_transfer_id, crc, payload, payload_len);
+    const int16_t result = enqueueTxFrames(ins, can_id, inout_transfer_id, crc, payload, payload_len);
 
     if (kind == CanardRequest)                      // Response Transfer ID must not be altered
     {
@@ -376,8 +381,8 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
 
         // take off the crc and store the payload
         rx_state->timestamp_usec = timestamp_usec;
-        const int ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data + 2,
-                                             (uint8_t) (frame->data_len - 3));
+        const int16_t ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data + 2,
+                                                 (uint8_t) (frame->data_len - 3));
         if (ret < 0)
         {
             releaseStatePayload(ins, rx_state);
@@ -390,8 +395,8 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
     }
     else if (!IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))    // Middle of a multi-frame transfer
     {
-        const int ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data,
-                                             (uint8_t) (frame->data_len - 1));
+        const int16_t ret = bufferBlockPushBytes(&ins->allocator, rx_state, frame->data,
+                                                 (uint8_t) (frame->data_len - 1));
         if (ret < 0)
         {
             releaseStatePayload(ins, rx_state);
@@ -506,11 +511,11 @@ void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec
     }
 }
 
-int canardDecodeScalar(const CanardRxTransfer* transfer,
-                       uint32_t bit_offset,
-                       uint8_t bit_length,
-                       bool value_is_signed,
-                       void* out_value)
+int16_t canardDecodeScalar(const CanardRxTransfer* transfer,
+                           uint32_t bit_offset,
+                           uint8_t bit_length,
+                           bool value_is_signed,
+                           void* out_value)
 {
     if (transfer == NULL || out_value == NULL)
     {
@@ -547,7 +552,7 @@ int canardDecodeScalar(const CanardRxTransfer* transfer,
 
     memset(&storage, 0, sizeof(storage));   // This is important
 
-    const int result = descatterTransferPayload(transfer, bit_offset, bit_length, &storage.bytes[0]);
+    const int16_t result = descatterTransferPayload(transfer, bit_offset, bit_length, &storage.bytes[0]);
     if (result <= 0)
     {
         return result;
@@ -859,12 +864,12 @@ CANARD_INTERNAL void incrementTransferID(uint8_t* transfer_id)
     }
 }
 
-CANARD_INTERNAL int enqueueTxFrames(CanardInstance* ins,
-                                    uint32_t can_id,
-                                    uint8_t* transfer_id,
-                                    uint16_t crc,
-                                    const uint8_t* payload,
-                                    uint16_t payload_len)
+CANARD_INTERNAL int16_t enqueueTxFrames(CanardInstance* ins,
+                                        uint32_t can_id,
+                                        uint8_t* transfer_id,
+                                        uint16_t crc,
+                                        const uint8_t* payload,
+                                        uint16_t payload_len)
 {
     CANARD_ASSERT(ins != NULL);
     CANARD_ASSERT((can_id & CANARD_CAN_EXT_ID_MASK) == can_id);            // Flags must be cleared
@@ -879,7 +884,7 @@ CANARD_INTERNAL int enqueueTxFrames(CanardInstance* ins,
         return -CANARD_ERROR_INVALID_ARGUMENT;
     }
 
-    int result = 0;
+    int16_t result = 0;
 
     if (payload_len < CANARD_CAN_FRAME_MAX_DATA_LEN)                        // Single frame transfer
     {
@@ -1211,15 +1216,15 @@ CANARD_INTERNAL uint64_t releaseStatePayload(CanardInstance* ins, CanardRxState*
 /**
  * pushes data into the rx state. Fills the buffer head, then appends data to buffer blocks
  */
-CANARD_INTERNAL int bufferBlockPushBytes(CanardPoolAllocator* allocator,
-                                         CanardRxState* state,
-                                         const uint8_t* data,
-                                         uint8_t data_len)
+CANARD_INTERNAL int16_t bufferBlockPushBytes(CanardPoolAllocator* allocator,
+                                             CanardRxState* state,
+                                             const uint8_t* data,
+                                             uint8_t data_len)
 {
     uint16_t data_index = 0;
 
     // if head is not full, add data to head
-    if ((int) CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE - (int) state->payload_len > 0)
+    if ((CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE - state->payload_len) > 0)
     {
         for (uint16_t i = (uint16_t)state->payload_len;
              i < CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE && data_index < data_len;
@@ -1354,10 +1359,10 @@ void copyBitArray(const uint8_t* src, uint32_t src_offset, uint32_t src_len,
     }
 }
 
-CANARD_INTERNAL int descatterTransferPayload(const CanardRxTransfer* transfer,
-                                             uint32_t bit_offset,
-                                             uint8_t bit_length,
-                                             void* output)
+CANARD_INTERNAL int16_t descatterTransferPayload(const CanardRxTransfer* transfer,
+                                                 uint32_t bit_offset,
+                                                 uint8_t bit_length,
+                                                 void* output)
 {
     CANARD_ASSERT(transfer != 0);
 
@@ -1472,14 +1477,14 @@ CANARD_INTERNAL bool isBigEndian(void)
 #endif
 }
 
-CANARD_INTERNAL void swapByteOrder(void* data, unsigned size)
+CANARD_INTERNAL void swapByteOrder(void* data, size_t size)
 {
     CANARD_ASSERT(data != NULL);
 
     uint8_t* const bytes = (uint8_t*) data;
 
-    unsigned fwd = 0;
-    unsigned rev = size - 1;
+    size_t fwd = 0;
+    size_t rev = size - 1;
 
     while (fwd < rev)
     {
@@ -1497,7 +1502,7 @@ CANARD_INTERNAL void swapByteOrder(void* data, unsigned size)
 CANARD_INTERNAL uint16_t crcAddByte(uint16_t crc_val, uint8_t byte)
 {
     crc_val ^= (uint16_t) ((uint16_t) (byte) << 8U);
-    for (int j = 0; j < 8; j++)
+    for (uint8_t j = 0; j < 8; j++)
     {
         if (crc_val & 0x8000U)
         {

--- a/canard.h
+++ b/canard.h
@@ -355,14 +355,16 @@ uint8_t canardGetLocalNodeID(const CanardInstance* ins);
  * Pointer to the Transfer ID should point to a persistent variable (e.g. static or heap allocated, not on the stack);
  * it will be updated by the library after every transmission. The Transfer ID value cannot be shared between
  * transfers that have different descriptors! More on this in the transport layer specification.
+ *
+ * Returns the number of frames enqueued, or negative error code.
  */
-int canardBroadcast(CanardInstance* ins,            ///< Library instance
-                    uint64_t data_type_signature,   ///< See above
-                    uint16_t data_type_id,          ///< Refer to the specification
-                    uint8_t* inout_transfer_id,     ///< Pointer to a persistent variable containing the transfer ID
-                    uint8_t priority,               ///< Refer to definitions CANARD_TRANSFER_PRIORITY_*
-                    const void* payload,            ///< Transfer payload
-                    uint16_t payload_len);          ///< Length of the above, in bytes
+int16_t canardBroadcast(CanardInstance* ins,            ///< Library instance
+                        uint64_t data_type_signature,   ///< See above
+                        uint16_t data_type_id,          ///< Refer to the specification
+                        uint8_t* inout_transfer_id,     ///< Pointer to a persistent variable containing the transfer ID
+                        uint8_t priority,               ///< Refer to definitions CANARD_TRANSFER_PRIORITY_*
+                        const void* payload,            ///< Transfer payload
+                        uint16_t payload_len);          ///< Length of the above, in bytes
 
 /**
  * Sends a request or a response transfer.
@@ -378,16 +380,18 @@ int canardBroadcast(CanardInstance* ins,            ///< Library instance
  *
  * For Response transfers, the pointer to the Transfer ID will be treated as const (i.e. read-only), and normally it
  * should point to the transfer_id field of the structure CanardRxTransfer.
+ *
+ * Returns the number of frames enqueued, or negative error code.
  */
-int canardRequestOrRespond(CanardInstance* ins,             ///< Library instance
-                           uint8_t destination_node_id,     ///< Node ID of the server/client
-                           uint64_t data_type_signature,    ///< See above
-                           uint8_t data_type_id,            ///< Refer to the specification
-                           uint8_t* inout_transfer_id,      ///< Pointer to a persistent variable with the transfer ID
-                           uint8_t priority,                ///< Refer to definitions CANARD_TRANSFER_PRIORITY_*
-                           CanardRequestResponse kind,      ///< Refer to CanardRequestResponse
-                           const void* payload,             ///< Transfer payload
-                           uint16_t payload_len);           ///< Length of the above, in bytes
+int16_t canardRequestOrRespond(CanardInstance* ins,             ///< Library instance
+                               uint8_t destination_node_id,     ///< Node ID of the server/client
+                               uint64_t data_type_signature,    ///< See above
+                               uint8_t data_type_id,            ///< Refer to the specification
+                               uint8_t* inout_transfer_id,      ///< Pointer to a persistent variable with transfer ID
+                               uint8_t priority,                ///< Refer to definitions CANARD_TRANSFER_PRIORITY_*
+                               CanardRequestResponse kind,      ///< Refer to CanardRequestResponse
+                               const void* payload,             ///< Transfer payload
+                               uint16_t payload_len);           ///< Length of the above, in bytes
 
 /**
  * Returns a pointer to the top priority frame in the TX queue.
@@ -448,11 +452,11 @@ void canardCleanupStaleTransfers(CanardInstance* ins,
  *  | [33, 64]   | false           | uint64_t                                 |
  *  | [33, 64]   | true            | int64_t, or 64-bit float                 |
  */
-int canardDecodeScalar(const CanardRxTransfer* transfer,    ///< The RX transfer where the data will be copied from
-                       uint32_t bit_offset,                 ///< Offset, in bits, from the beginning of the transfer
-                       uint8_t bit_length,                  ///< Length of the value, in bits; see the table
-                       bool value_is_signed,                ///< True if the value can be negative; see the table
-                       void* out_value);                    ///< Pointer to the output storage; see the table
+int16_t canardDecodeScalar(const CanardRxTransfer* transfer,    ///< The RX transfer where the data will be copied from
+                           uint32_t bit_offset,                 ///< Offset, in bits, from the beginning of the transfer
+                           uint8_t bit_length,                  ///< Length of the value, in bits; see the table
+                           bool value_is_signed,                ///< True if the value can be negative; see the table
+                           void* out_value);                    ///< Pointer to the output storage; see the table
 
 /**
  * This function can be used to encode values for later transmission in a UAVCAN transfer. It encodes a scalar value -

--- a/canard_internals.h
+++ b/canard_internals.h
@@ -56,10 +56,10 @@ CANARD_INTERNAL CanardRxState* prependRxState(CanardInstance* ins,
 CANARD_INTERNAL CanardRxState* findRxState(CanardRxState* state,
                                            uint32_t transfer_descriptor);
 
-CANARD_INTERNAL int bufferBlockPushBytes(CanardPoolAllocator* allocator,
-                                         CanardRxState* state,
-                                         const uint8_t* data,
-                                         uint8_t data_len);
+CANARD_INTERNAL int16_t bufferBlockPushBytes(CanardPoolAllocator* allocator,
+                                             CanardRxState* state,
+                                             const uint8_t* data,
+                                             uint8_t data_len);
 
 CANARD_INTERNAL CanardBufferBlock* createBufferBlock(CanardPoolAllocator* allocator);
 
@@ -86,12 +86,12 @@ CANARD_INTERNAL uint64_t releaseStatePayload(CanardInstance* ins,
                                              CanardRxState* rxstate);
 
 /// Returns the number of frames enqueued
-CANARD_INTERNAL int enqueueTxFrames(CanardInstance* ins,
-                                    uint32_t can_id,
-                                    uint8_t* transfer_id,
-                                    uint16_t crc,
-                                    const uint8_t* payload,
-                                    uint16_t payload_len);
+CANARD_INTERNAL int16_t enqueueTxFrames(CanardInstance* ins,
+                                        uint32_t can_id,
+                                        uint8_t* transfer_id,
+                                        uint16_t crc,
+                                        const uint8_t* payload,
+                                        uint16_t payload_len);
 
 CANARD_INTERNAL void copyBitArray(const uint8_t* src,
                                   uint32_t src_offset,
@@ -103,10 +103,10 @@ CANARD_INTERNAL void copyBitArray(const uint8_t* src,
  * Moves specified bits from the scattered transfer storage to a specified contiguous buffer.
  * Returns the number of bits copied, or negated error code.
  */
-CANARD_INTERNAL int descatterTransferPayload(const CanardRxTransfer* transfer,
-                                             uint32_t bit_offset,
-                                             uint8_t bit_length,
-                                             void* output);
+CANARD_INTERNAL int16_t descatterTransferPayload(const CanardRxTransfer* transfer,
+                                                 uint32_t bit_offset,
+                                                 uint8_t bit_length,
+                                                 void* output);
 
 CANARD_INTERNAL bool isBigEndian(void);
 

--- a/drivers/socketcan/socketcan.c
+++ b/drivers/socketcan/socketcan.c
@@ -50,7 +50,7 @@ int16_t socketcanInit(SocketCANInstance* out_ins, const char* can_iface_name)
         goto fail0;
     }
 
-    const int fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);
+    const int fd = socket(PF_CAN, SOCK_RAW | SOCK_NONBLOCK, CAN_RAW);  // NOLINT
     if (fd < 0)
     {
         goto fail0;

--- a/drivers/socketcan/socketcan.h
+++ b/drivers/socketcan/socketcan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 UAVCAN Team
+ * Copyright (c) 2016-2018 UAVCAN Team
  *
  * Distributed under the MIT License, available in the file LICENSE.
  *
@@ -22,28 +22,33 @@ typedef struct
 
 /**
  * Initializes the SocketCAN instance.
+ * Returns 0 on success, negative on error.
  */
-int socketcanInit(SocketCANInstance* out_ins, const char* can_iface_name);
+int16_t socketcanInit(SocketCANInstance* out_ins, const char* can_iface_name);
 
 /**
  * Deinitializes the SocketCAN instance.
+ * Returns 0 on success, negative on error.
  */
-int socketcanClose(SocketCANInstance* ins);
+int16_t socketcanClose(SocketCANInstance* ins);
 
 /**
  * Transmits a CanardCANFrame to the CAN socket.
  * Use negative timeout to block infinitely.
+ * Returns 1 on successful transmission, 0 on timeout, negative on error.
  */
-int socketcanTransmit(SocketCANInstance* ins, const CanardCANFrame* frame, int timeout_msec);
+int16_t socketcanTransmit(SocketCANInstance* ins, const CanardCANFrame* frame, int32_t timeout_msec);
 
 /**
  * Receives a CanardCANFrame from the CAN socket.
  * Use negative timeout to block infinitely.
+ * Returns 1 on successful reception, 0 on timeout, negative on error.
  */
-int socketcanReceive(SocketCANInstance* ins, CanardCANFrame* out_frame, int timeout_msec);
+int16_t socketcanReceive(SocketCANInstance* ins, CanardCANFrame* out_frame, int32_t timeout_msec);
 
 /**
  * Returns the file descriptor of the CAN socket.
+ * Can be used for external IO multiplexing.
  */
 int socketcanGetSocketFileDescriptor(const SocketCANInstance* ins);
 

--- a/drivers/stm32/_internal_bxcan.h
+++ b/drivers/stm32/_internal_bxcan.h
@@ -63,91 +63,91 @@ typedef struct
 /**
  * CANx instances
  */
-#define CANARD_STM32_CAN1       ((volatile CanardSTM32CANType*)0x40006400)
-#define CANARD_STM32_CAN2       ((volatile CanardSTM32CANType*)0x40006800)
+#define CANARD_STM32_CAN1       ((volatile CanardSTM32CANType*)0x40006400U)
+#define CANARD_STM32_CAN2       ((volatile CanardSTM32CANType*)0x40006800U)
 
 // CAN master control register
 
-#define CANARD_STM32_CAN_MCR_INRQ              (1U << 0)  // Bit 0: Initialization Request
-#define CANARD_STM32_CAN_MCR_SLEEP             (1U << 1)  // Bit 1: Sleep Mode Request
-#define CANARD_STM32_CAN_MCR_TXFP              (1U << 2)  // Bit 2: Transmit FIFO Priority
-#define CANARD_STM32_CAN_MCR_RFLM              (1U << 3)  // Bit 3: Receive FIFO Locked Mode
-#define CANARD_STM32_CAN_MCR_NART              (1U << 4)  // Bit 4: No Automatic Retransmission
-#define CANARD_STM32_CAN_MCR_AWUM              (1U << 5)  // Bit 5: Automatic Wakeup Mode
-#define CANARD_STM32_CAN_MCR_ABOM              (1U << 6)  // Bit 6: Automatic Bus-Off Management
-#define CANARD_STM32_CAN_MCR_TTCM              (1U << 7)  // Bit 7: Time Triggered Communication Mode Enable
-#define CANARD_STM32_CAN_MCR_RESET             (1U << 15) // Bit 15: bxCAN software master reset
-#define CANARD_STM32_CAN_MCR_DBF               (1U << 16) // Bit 16: Debug freeze
+#define CANARD_STM32_CAN_MCR_INRQ              (1U << 0U)  // Bit 0: Initialization Request
+#define CANARD_STM32_CAN_MCR_SLEEP             (1U << 1U)  // Bit 1: Sleep Mode Request
+#define CANARD_STM32_CAN_MCR_TXFP              (1U << 2U)  // Bit 2: Transmit FIFO Priority
+#define CANARD_STM32_CAN_MCR_RFLM              (1U << 3U)  // Bit 3: Receive FIFO Locked Mode
+#define CANARD_STM32_CAN_MCR_NART              (1U << 4U)  // Bit 4: No Automatic Retransmission
+#define CANARD_STM32_CAN_MCR_AWUM              (1U << 5U)  // Bit 5: Automatic Wakeup Mode
+#define CANARD_STM32_CAN_MCR_ABOM              (1U << 6U)  // Bit 6: Automatic Bus-Off Management
+#define CANARD_STM32_CAN_MCR_TTCM              (1U << 7U)  // Bit 7: Time Triggered Communication Mode Enable
+#define CANARD_STM32_CAN_MCR_RESET             (1U << 15U) // Bit 15: bxCAN software master reset
+#define CANARD_STM32_CAN_MCR_DBF               (1U << 16U) // Bit 16: Debug freeze
 
 // CAN master status register
 
-#define CANARD_STM32_CAN_MSR_INAK              (1U << 0)  // Bit 0: Initialization Acknowledge
-#define CANARD_STM32_CAN_MSR_SLAK              (1U << 1)  // Bit 1: Sleep Acknowledge
-#define CANARD_STM32_CAN_MSR_ERRI              (1U << 2)  // Bit 2: Error Interrupt
-#define CANARD_STM32_CAN_MSR_WKUI              (1U << 3)  // Bit 3: Wakeup Interrupt
-#define CANARD_STM32_CAN_MSR_SLAKI             (1U << 4)  // Bit 4: Sleep acknowledge interrupt
-#define CANARD_STM32_CAN_MSR_TXM               (1U << 8)  // Bit 8: Transmit Mode
-#define CANARD_STM32_CAN_MSR_RXM               (1U << 9)  // Bit 9: Receive Mode
-#define CANARD_STM32_CAN_MSR_SAMP              (1U << 10) // Bit 10: Last Sample Point
-#define CANARD_STM32_CAN_MSR_RX                (1U << 11) // Bit 11: CAN Rx Signal
+#define CANARD_STM32_CAN_MSR_INAK              (1U << 0U)  // Bit 0: Initialization Acknowledge
+#define CANARD_STM32_CAN_MSR_SLAK              (1U << 1U)  // Bit 1: Sleep Acknowledge
+#define CANARD_STM32_CAN_MSR_ERRI              (1U << 2U)  // Bit 2: Error Interrupt
+#define CANARD_STM32_CAN_MSR_WKUI              (1U << 3U)  // Bit 3: Wakeup Interrupt
+#define CANARD_STM32_CAN_MSR_SLAKI             (1U << 4U)  // Bit 4: Sleep acknowledge interrupt
+#define CANARD_STM32_CAN_MSR_TXM               (1U << 8U)  // Bit 8: Transmit Mode
+#define CANARD_STM32_CAN_MSR_RXM               (1U << 9U)  // Bit 9: Receive Mode
+#define CANARD_STM32_CAN_MSR_SAMP              (1U << 10U) // Bit 10: Last Sample Point
+#define CANARD_STM32_CAN_MSR_RX                (1U << 11U) // Bit 11: CAN Rx Signal
 
 // CAN transmit status register
 
-#define CANARD_STM32_CAN_TSR_RQCP0             (1U << 0)  // Bit 0: Request Completed Mailbox 0
-#define CANARD_STM32_CAN_TSR_TXOK0             (1U << 1)  // Bit 1 : Transmission OK of Mailbox 0
-#define CANARD_STM32_CAN_TSR_ALST0             (1U << 2)  // Bit 2 : Arbitration Lost for Mailbox 0
-#define CANARD_STM32_CAN_TSR_TERR0             (1U << 3)  // Bit 3 : Transmission Error of Mailbox 0
-#define CANARD_STM32_CAN_TSR_ABRQ0             (1U << 7)  // Bit 7 : Abort Request for Mailbox 0
-#define CANARD_STM32_CAN_TSR_RQCP1             (1U << 8)  // Bit 8 : Request Completed Mailbox 1
-#define CANARD_STM32_CAN_TSR_TXOK1             (1U << 9)  // Bit 9 : Transmission OK of Mailbox 1
-#define CANARD_STM32_CAN_TSR_ALST1             (1U << 10) // Bit 10 : Arbitration Lost for Mailbox 1
-#define CANARD_STM32_CAN_TSR_TERR1             (1U << 11) // Bit 11 : Transmission Error of Mailbox 1
-#define CANARD_STM32_CAN_TSR_ABRQ1             (1U << 15) // Bit 15 : Abort Request for Mailbox 1
-#define CANARD_STM32_CAN_TSR_RQCP2             (1U << 16) // Bit 16 : Request Completed Mailbox 2
-#define CANARD_STM32_CAN_TSR_TXOK2             (1U << 17) // Bit 17 : Transmission OK of Mailbox 2
-#define CANARD_STM32_CAN_TSR_ALST2             (1U << 18) // Bit 18: Arbitration Lost for Mailbox 2
-#define CANARD_STM32_CAN_TSR_TERR2             (1U << 19) // Bit 19: Transmission Error of Mailbox 2
-#define CANARD_STM32_CAN_TSR_ABRQ2             (1U << 23) // Bit 23: Abort Request for Mailbox 2
-#define CANARD_STM32_CAN_TSR_CODE_SHIFT        (24U)      // Bits 25-24: Mailbox Code
+#define CANARD_STM32_CAN_TSR_RQCP0             (1U << 0U)  // Bit 0: Request Completed Mailbox 0
+#define CANARD_STM32_CAN_TSR_TXOK0             (1U << 1U)  // Bit 1 : Transmission OK of Mailbox 0
+#define CANARD_STM32_CAN_TSR_ALST0             (1U << 2U)  // Bit 2 : Arbitration Lost for Mailbox 0
+#define CANARD_STM32_CAN_TSR_TERR0             (1U << 3U)  // Bit 3 : Transmission Error of Mailbox 0
+#define CANARD_STM32_CAN_TSR_ABRQ0             (1U << 7U)  // Bit 7 : Abort Request for Mailbox 0
+#define CANARD_STM32_CAN_TSR_RQCP1             (1U << 8U)  // Bit 8 : Request Completed Mailbox 1
+#define CANARD_STM32_CAN_TSR_TXOK1             (1U << 9U)  // Bit 9 : Transmission OK of Mailbox 1
+#define CANARD_STM32_CAN_TSR_ALST1             (1U << 10U) // Bit 10 : Arbitration Lost for Mailbox 1
+#define CANARD_STM32_CAN_TSR_TERR1             (1U << 11U) // Bit 11 : Transmission Error of Mailbox 1
+#define CANARD_STM32_CAN_TSR_ABRQ1             (1U << 15U) // Bit 15 : Abort Request for Mailbox 1
+#define CANARD_STM32_CAN_TSR_RQCP2             (1U << 16U) // Bit 16 : Request Completed Mailbox 2
+#define CANARD_STM32_CAN_TSR_TXOK2             (1U << 17U) // Bit 17 : Transmission OK of Mailbox 2
+#define CANARD_STM32_CAN_TSR_ALST2             (1U << 18U) // Bit 18: Arbitration Lost for Mailbox 2
+#define CANARD_STM32_CAN_TSR_TERR2             (1U << 19U) // Bit 19: Transmission Error of Mailbox 2
+#define CANARD_STM32_CAN_TSR_ABRQ2             (1U << 23U) // Bit 23: Abort Request for Mailbox 2
+#define CANARD_STM32_CAN_TSR_CODE_SHIFT        (24U)       // Bits 25-24: Mailbox Code
 #define CANARD_STM32_CAN_TSR_CODE_MASK         (3U << CANARD_STM32_CAN_TSR_CODE_SHIFT)
-#define CANARD_STM32_CAN_TSR_TME0              (1U << 26) // Bit 26: Transmit Mailbox 0 Empty
-#define CANARD_STM32_CAN_TSR_TME1              (1U << 27) // Bit 27: Transmit Mailbox 1 Empty
-#define CANARD_STM32_CAN_TSR_TME2              (1U << 28) // Bit 28: Transmit Mailbox 2 Empty
-#define CANARD_STM32_CAN_TSR_LOW0              (1U << 29) // Bit 29: Lowest Priority Flag for Mailbox 0
-#define CANARD_STM32_CAN_TSR_LOW1              (1U << 30) // Bit 30: Lowest Priority Flag for Mailbox 1
-#define CANARD_STM32_CAN_TSR_LOW2              (1U << 31) // Bit 31: Lowest Priority Flag for Mailbox 2
+#define CANARD_STM32_CAN_TSR_TME0              (1U << 26U) // Bit 26: Transmit Mailbox 0 Empty
+#define CANARD_STM32_CAN_TSR_TME1              (1U << 27U) // Bit 27: Transmit Mailbox 1 Empty
+#define CANARD_STM32_CAN_TSR_TME2              (1U << 28U) // Bit 28: Transmit Mailbox 2 Empty
+#define CANARD_STM32_CAN_TSR_LOW0              (1U << 29U) // Bit 29: Lowest Priority Flag for Mailbox 0
+#define CANARD_STM32_CAN_TSR_LOW1              (1U << 30U) // Bit 30: Lowest Priority Flag for Mailbox 1
+#define CANARD_STM32_CAN_TSR_LOW2              (1U << 31U) // Bit 31: Lowest Priority Flag for Mailbox 2
 
 // CAN receive FIFO 0/1 registers
 
-#define CANARD_STM32_CAN_RFR_FMP_SHIFT         (0U)       // Bits 1-0: FIFO Message Pending
+#define CANARD_STM32_CAN_RFR_FMP_SHIFT         (0U)        // Bits 1-0: FIFO Message Pending
 #define CANARD_STM32_CAN_RFR_FMP_MASK          (3U << CANARD_STM32_CAN_RFR_FMP_SHIFT)
-#define CANARD_STM32_CAN_RFR_FULL              (1U << 3)  // Bit 3: FIFO 0 Full
-#define CANARD_STM32_CAN_RFR_FOVR              (1U << 4)  // Bit 4: FIFO 0 Overrun
-#define CANARD_STM32_CAN_RFR_RFOM              (1U << 5)  // Bit 5: Release FIFO 0 Output Mailbox
+#define CANARD_STM32_CAN_RFR_FULL              (1U << 3U)  // Bit 3: FIFO 0 Full
+#define CANARD_STM32_CAN_RFR_FOVR              (1U << 4U)  // Bit 4: FIFO 0 Overrun
+#define CANARD_STM32_CAN_RFR_RFOM              (1U << 5U)  // Bit 5: Release FIFO 0 Output Mailbox
 
 // CAN interrupt enable register
 
-#define CANARD_STM32_CAN_IER_TMEIE             (1U << 0)  // Bit 0: Transmit Mailbox Empty Interrupt Enable
-#define CANARD_STM32_CAN_IER_FMPIE0            (1U << 1)  // Bit 1: FIFO Message Pending Interrupt Enable
-#define CANARD_STM32_CAN_IER_FFIE0             (1U << 2)  // Bit 2: FIFO Full Interrupt Enable
-#define CANARD_STM32_CAN_IER_FOVIE0            (1U << 3)  // Bit 3: FIFO Overrun Interrupt Enable
-#define CANARD_STM32_CAN_IER_FMPIE1            (1U << 4)  // Bit 4: FIFO Message Pending Interrupt Enable
-#define CANARD_STM32_CAN_IER_FFIE1             (1U << 5)  // Bit 5: FIFO Full Interrupt Enable
-#define CANARD_STM32_CAN_IER_FOVIE1            (1U << 6)  // Bit 6: FIFO Overrun Interrupt Enable
-#define CANARD_STM32_CAN_IER_EWGIE             (1U << 8)  // Bit 8: Error Warning Interrupt Enable
-#define CANARD_STM32_CAN_IER_EPVIE             (1U << 9)  // Bit 9: Error Passive Interrupt Enable
-#define CANARD_STM32_CAN_IER_BOFIE             (1U << 10) // Bit 10: Bus-Off Interrupt Enable
-#define CANARD_STM32_CAN_IER_LECIE             (1U << 11) // Bit 11: Last Error Code Interrupt Enable
-#define CANARD_STM32_CAN_IER_ERRIE             (1U << 15) // Bit 15: Error Interrupt Enable
-#define CANARD_STM32_CAN_IER_WKUIE             (1U << 16) // Bit 16: Wakeup Interrupt Enable
-#define CANARD_STM32_CAN_IER_SLKIE             (1U << 17) // Bit 17: Sleep Interrupt Enable
+#define CANARD_STM32_CAN_IER_TMEIE             (1U << 0U)  // Bit 0: Transmit Mailbox Empty Interrupt Enable
+#define CANARD_STM32_CAN_IER_FMPIE0            (1U << 1U)  // Bit 1: FIFO Message Pending Interrupt Enable
+#define CANARD_STM32_CAN_IER_FFIE0             (1U << 2U)  // Bit 2: FIFO Full Interrupt Enable
+#define CANARD_STM32_CAN_IER_FOVIE0            (1U << 3U)  // Bit 3: FIFO Overrun Interrupt Enable
+#define CANARD_STM32_CAN_IER_FMPIE1            (1U << 4U)  // Bit 4: FIFO Message Pending Interrupt Enable
+#define CANARD_STM32_CAN_IER_FFIE1             (1U << 5U)  // Bit 5: FIFO Full Interrupt Enable
+#define CANARD_STM32_CAN_IER_FOVIE1            (1U << 6U)  // Bit 6: FIFO Overrun Interrupt Enable
+#define CANARD_STM32_CAN_IER_EWGIE             (1U << 8U)  // Bit 8: Error Warning Interrupt Enable
+#define CANARD_STM32_CAN_IER_EPVIE             (1U << 9U)  // Bit 9: Error Passive Interrupt Enable
+#define CANARD_STM32_CAN_IER_BOFIE             (1U << 10U) // Bit 10: Bus-Off Interrupt Enable
+#define CANARD_STM32_CAN_IER_LECIE             (1U << 11U) // Bit 11: Last Error Code Interrupt Enable
+#define CANARD_STM32_CAN_IER_ERRIE             (1U << 15U) // Bit 15: Error Interrupt Enable
+#define CANARD_STM32_CAN_IER_WKUIE             (1U << 16U) // Bit 16: Wakeup Interrupt Enable
+#define CANARD_STM32_CAN_IER_SLKIE             (1U << 17U) // Bit 17: Sleep Interrupt Enable
 
 // CAN error status register
 
-#define CANARD_STM32_CAN_ESR_EWGF              (1U << 0)  // Bit 0: Error Warning Flag
-#define CANARD_STM32_CAN_ESR_EPVF              (1U << 1)  // Bit 1: Error Passive Flag
-#define CANARD_STM32_CAN_ESR_BOFF              (1U << 2)  // Bit 2: Bus-Off Flag
-#define CANARD_STM32_CAN_ESR_LEC_SHIFT         (4U)       // Bits 6-4: Last Error Code
+#define CANARD_STM32_CAN_ESR_EWGF              (1U << 0U)  // Bit 0: Error Warning Flag
+#define CANARD_STM32_CAN_ESR_EPVF              (1U << 1U)  // Bit 1: Error Passive Flag
+#define CANARD_STM32_CAN_ESR_BOFF              (1U << 2U)  // Bit 2: Bus-Off Flag
+#define CANARD_STM32_CAN_ESR_LEC_SHIFT         (4U)        // Bits 6-4: Last Error Code
 #define CANARD_STM32_CAN_ESR_LEC_MASK          (7U << CANARD_STM32_CAN_ESR_LEC_SHIFT)
 #define CANARD_STM32_CAN_ESR_NOERROR           (0U << CANARD_STM32_CAN_ESR_LEC_SHIFT) // 000: No Error
 #define CANARD_STM32_CAN_ESR_STUFFERROR        (1U << CANARD_STM32_CAN_ESR_LEC_SHIFT) // 001: Stuff Error
@@ -157,66 +157,66 @@ typedef struct
 #define CANARD_STM32_CAN_ESR_BDOMERROR         (5U << CANARD_STM32_CAN_ESR_LEC_SHIFT) // 101: Bit dominant Error
 #define CANARD_STM32_CAN_ESR_CRCERRPR          (6U << CANARD_STM32_CAN_ESR_LEC_SHIFT) // 110: CRC Error
 #define CANARD_STM32_CAN_ESR_SWERROR           (7U << CANARD_STM32_CAN_ESR_LEC_SHIFT) // 111: Set by software
-#define CANARD_STM32_CAN_ESR_TEC_SHIFT         (16U)      // Bits 23-16: LS byte of the 9-bit Transmit Error Counter
+#define CANARD_STM32_CAN_ESR_TEC_SHIFT         (16U)       // Bits 23-16: LS byte of the 9-bit Transmit Error Counter
 #define CANARD_STM32_CAN_ESR_TEC_MASK          (0xFFU << CANARD_STM32_CAN_ESR_TEC_SHIFT)
-#define CANARD_STM32_CAN_ESR_REC_SHIFT         (24U)      // Bits 31-24: Receive Error Counter
+#define CANARD_STM32_CAN_ESR_REC_SHIFT         (24U)       // Bits 31-24: Receive Error Counter
 #define CANARD_STM32_CAN_ESR_REC_MASK          (0xFFU << CANARD_STM32_CAN_ESR_REC_SHIFT)
 
 // CAN bit timing register
 
-#define CANARD_STM32_CAN_BTR_BRP_SHIFT         (0U)       // Bits 9-0: Baud Rate Prescaler
+#define CANARD_STM32_CAN_BTR_BRP_SHIFT         (0U)        // Bits 9-0: Baud Rate Prescaler
 #define CANARD_STM32_CAN_BTR_BRP_MASK          (0x03FFU << CANARD_STM32_CAN_BTR_BRP_SHIFT)
-#define CANARD_STM32_CAN_BTR_TS1_SHIFT         (16U)      // Bits 19-16: Time Segment 1
+#define CANARD_STM32_CAN_BTR_TS1_SHIFT         (16U)       // Bits 19-16: Time Segment 1
 #define CANARD_STM32_CAN_BTR_TS1_MASK          (0x0FU <<  CANARD_STM32_CAN_BTR_TS1_SHIFT)
-#define CANARD_STM32_CAN_BTR_TS2_SHIFT         (20U)      // Bits 22-20: Time Segment 2
+#define CANARD_STM32_CAN_BTR_TS2_SHIFT         (20U)       // Bits 22-20: Time Segment 2
 #define CANARD_STM32_CAN_BTR_TS2_MASK          (7U << CANARD_STM32_CAN_BTR_TS2_SHIFT)
-#define CANARD_STM32_CAN_BTR_SJW_SHIFT         (24U)      // Bits 25-24: Resynchronization Jump Width
+#define CANARD_STM32_CAN_BTR_SJW_SHIFT         (24U)       // Bits 25-24: Resynchronization Jump Width
 #define CANARD_STM32_CAN_BTR_SJW_MASK          (3U << CANARD_STM32_CAN_BTR_SJW_SHIFT)
-#define CANARD_STM32_CAN_BTR_LBKM              (1U << 30) // Bit 30: Loop Back Mode (Debug);
-#define CANARD_STM32_CAN_BTR_SILM              (1U << 31) // Bit 31: Silent Mode (Debug);
+#define CANARD_STM32_CAN_BTR_LBKM              (1U << 30U) // Bit 30: Loop Back Mode (Debug);
+#define CANARD_STM32_CAN_BTR_SILM              (1U << 31U) // Bit 31: Silent Mode (Debug);
 
-#define CANARD_STM32_CAN_BTR_BRP_MAX           (1024U)    // Maximum BTR value (without decrement);
-#define CANARD_STM32_CAN_BTR_TSEG1_MAX         (16U)      // Maximum TSEG1 value (without decrement);
-#define CANARD_STM32_CAN_BTR_TSEG2_MAX         (8U)       // Maximum TSEG2 value (without decrement);
+#define CANARD_STM32_CAN_BTR_BRP_MAX           (1024U)     // Maximum BTR value (without decrement);
+#define CANARD_STM32_CAN_BTR_TSEG1_MAX         (16U)       // Maximum TSEG1 value (without decrement);
+#define CANARD_STM32_CAN_BTR_TSEG2_MAX         (8U)        // Maximum TSEG2 value (without decrement);
 
 // TX mailbox identifier register
 
-#define CANARD_STM32_CAN_TIR_TXRQ              (1U << 0)  // Bit 0: Transmit Mailbox Request
-#define CANARD_STM32_CAN_TIR_RTR               (1U << 1)  // Bit 1: Remote Transmission Request
-#define CANARD_STM32_CAN_TIR_IDE               (1U << 2)  // Bit 2: Identifier Extension
-#define CANARD_STM32_CAN_TIR_EXID_SHIFT        (3U)       // Bit 3-31: Extended Identifier
+#define CANARD_STM32_CAN_TIR_TXRQ              (1U << 0U)  // Bit 0: Transmit Mailbox Request
+#define CANARD_STM32_CAN_TIR_RTR               (1U << 1U)  // Bit 1: Remote Transmission Request
+#define CANARD_STM32_CAN_TIR_IDE               (1U << 2U)  // Bit 2: Identifier Extension
+#define CANARD_STM32_CAN_TIR_EXID_SHIFT        (3U)        // Bit 3-31: Extended Identifier
 #define CANARD_STM32_CAN_TIR_EXID_MASK         (0x1FFFFFFFU << CANARD_STM32_CAN_TIR_EXID_SHIFT)
-#define CANARD_STM32_CAN_TIR_STID_SHIFT        (21U)      // Bits 21-31: Standard Identifier
+#define CANARD_STM32_CAN_TIR_STID_SHIFT        (21U)       // Bits 21-31: Standard Identifier
 #define CANARD_STM32_CAN_TIR_STID_MASK         (0x07FFU << CANARD_STM32_CAN_TIR_STID_SHIFT)
 
 // Mailbox data length control and time stamp register
 
-#define CANARD_STM32_CAN_TDTR_DLC_SHIFT        (0U)       // Bits 3:0: Data Length Code
+#define CANARD_STM32_CAN_TDTR_DLC_SHIFT        (0U)        // Bits 3:0: Data Length Code
 #define CANARD_STM32_CAN_TDTR_DLC_MASK         (0x0FU << CANARD_STM32_CAN_TDTR_DLC_SHIFT)
-#define CANARD_STM32_CAN_TDTR_TGT              (1U << 8)  // Bit 8: Transmit Global Time
-#define CANARD_STM32_CAN_TDTR_TIME_SHIFT       (16U)      // Bits 31:16: Message Time Stamp
+#define CANARD_STM32_CAN_TDTR_TGT              (1U << 8U)  // Bit 8: Transmit Global Time
+#define CANARD_STM32_CAN_TDTR_TIME_SHIFT       (16U)       // Bits 31:16: Message Time Stamp
 #define CANARD_STM32_CAN_TDTR_TIME_MASK        (0xFFFFU << CANARD_STM32_CAN_TDTR_TIME_SHIFT)
 
 // Rx FIFO mailbox identifier register
 
-#define CANARD_STM32_CAN_RIR_RTR               (1U << 1)  // Bit 1: Remote Transmission Request
-#define CANARD_STM32_CAN_RIR_IDE               (1U << 2)  // Bit 2: Identifier Extension
-#define CANARD_STM32_CAN_RIR_EXID_SHIFT        (3U)       // Bit 3-31: Extended Identifier
+#define CANARD_STM32_CAN_RIR_RTR               (1U << 1U)  // Bit 1: Remote Transmission Request
+#define CANARD_STM32_CAN_RIR_IDE               (1U << 2U)  // Bit 2: Identifier Extension
+#define CANARD_STM32_CAN_RIR_EXID_SHIFT        (3U)        // Bit 3-31: Extended Identifier
 #define CANARD_STM32_CAN_RIR_EXID_MASK         (0x1FFFFFFFU << CANARD_STM32_CAN_RIR_EXID_SHIFT)
-#define CANARD_STM32_CAN_RIR_STID_SHIFT        (21U)      // Bits 21-31: Standard Identifier
+#define CANARD_STM32_CAN_RIR_STID_SHIFT        (21U)       // Bits 21-31: Standard Identifier
 #define CANARD_STM32_CAN_RIR_STID_MASK         (0x07FFU << CANARD_STM32_CAN_RIR_STID_SHIFT)
 
 // Receive FIFO mailbox data length control and time stamp register
 
-#define CANARD_STM32_CAN_RDTR_DLC_SHIFT        (0U)       // Bits 3:0: Data Length Code
+#define CANARD_STM32_CAN_RDTR_DLC_SHIFT        (0U)        // Bits 3:0: Data Length Code
 #define CANARD_STM32_CAN_RDTR_DLC_MASK         (0x0FU << CANARD_STM32_CAN_RDTR_DLC_SHIFT)
-#define CANARD_STM32_CAN_RDTR_FM_SHIFT         (8U)       // Bits 15-8: Filter Match Index
+#define CANARD_STM32_CAN_RDTR_FM_SHIFT         (8U)        // Bits 15-8: Filter Match Index
 #define CANARD_STM32_CAN_RDTR_FM_MASK          (0xFFU << CANARD_STM32_CAN_RDTR_FM_SHIFT)
-#define CANARD_STM32_CAN_RDTR_TIME_SHIFT       (16U)      // Bits 31:16: Message Time Stamp
+#define CANARD_STM32_CAN_RDTR_TIME_SHIFT       (16U)       // Bits 31:16: Message Time Stamp
 #define CANARD_STM32_CAN_RDTR_TIME_MASK        (0xFFFFU << CANARD_STM32_CAN_RDTR_TIME_SHIFT)
 
 // CAN filter master register
 
-#define CANARD_STM32_CAN_FMR_FINIT             (1U << 0)  // Bit 0:  Filter Init Mode
+#define CANARD_STM32_CAN_FMR_FINIT             (1U << 0U)  // Bit 0:  Filter Init Mode
 
 #endif // CANARD_STM32_BXCAN_H

--- a/drivers/stm32/canard_stm32.h
+++ b/drivers/stm32/canard_stm32.h
@@ -10,7 +10,7 @@
 #define CANARD_STM32_H
 
 #include <canard.h>
-#include <string.h>
+#include <string.h>     // NOLINT
 
 
 #ifdef __cplusplus
@@ -196,7 +196,7 @@ int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
         return -CANARD_STM32_ERROR_UNSUPPORTED_BIT_RATE;
     }
 
-    CANARD_ASSERT(out_timings != NULL);
+    CANARD_ASSERT(out_timings != NULL);  // NOLINT
     memset(out_timings, 0, sizeof(*out_timings));
 
     /*
@@ -216,7 +216,7 @@ int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
      *   250  kbps      16      17
      *   125  kbps      16      17
      */
-    const uint8_t max_quanta_per_bit = (uint8_t)((target_bitrate >= 1000000) ? 10 : 17);
+    const uint8_t max_quanta_per_bit = (uint8_t)((target_bitrate >= 1000000) ? 10 : 17);    // NOLINT
     CANARD_ASSERT(max_quanta_per_bit <= (MaxBS1 + MaxBS2));
 
     static const uint16_t MaxSamplePointLocationPermill = 900;
@@ -236,7 +236,7 @@ int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
     /*
      * Searching for such prescaler value so that the number of quanta per bit is highest.
      */
-    uint8_t bs1_bs2_sum = (uint8_t)(max_quanta_per_bit - 1);
+    uint8_t bs1_bs2_sum = (uint8_t)(max_quanta_per_bit - 1);    // NOLINT
 
     while ((prescaler_bs % (1U + bs1_bs2_sum)) != 0)
     {
@@ -272,12 +272,12 @@ int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
      *   - With rounding to nearest
      *   - With rounding to zero
      */
-    uint8_t bs1 = (uint8_t)(((7 * bs1_bs2_sum - 1) + 4) / 8);       // Trying rounding to nearest first
-    uint8_t bs2 = (uint8_t)(bs1_bs2_sum - bs1);
+    uint8_t bs1 = (uint8_t)(((7 * bs1_bs2_sum - 1) + 4) / 8);       // Trying rounding to nearest first  // NOLINT
+    uint8_t bs2 = (uint8_t)(bs1_bs2_sum - bs1);  // NOLINT
     CANARD_ASSERT(bs1_bs2_sum > bs1);
 
     {
-        const uint16_t sample_point_permill = (uint16_t)(1000U * (1U + bs1) / (1U + bs1 + bs2));
+        const uint16_t sample_point_permill = (uint16_t)(1000U * (1U + bs1) / (1U + bs1 + bs2));  // NOLINT
 
         if (sample_point_permill > MaxSamplePointLocationPermill)   // Strictly more!
         {
@@ -300,7 +300,7 @@ int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
         !valid)
     {
         // This actually means that the algorithm has a logic error, hence assert(0).
-        CANARD_ASSERT(0);
+        CANARD_ASSERT(0);  // NOLINT
         return -CANARD_STM32_ERROR_UNSUPPORTED_BIT_RATE;
     }
 

--- a/drivers/stm32/canard_stm32.h
+++ b/drivers/stm32/canard_stm32.h
@@ -51,7 +51,7 @@ extern "C"
  * which is a number from 1 to 27 inclusive. Seeing as the start bank cannot be set to 0, CAN2 has one filter less
  * to use.
  */
-#define CANARD_STM32_NUM_ACCEPTANCE_FILTERS                            14
+#define CANARD_STM32_NUM_ACCEPTANCE_FILTERS                            14U
 
 /**
  * The interface can be initialized in either of these modes.
@@ -128,8 +128,8 @@ typedef struct
  * @retval      0               Success
  * @retval      negative        Error
  */
-int canardSTM32Init(const CanardSTM32CANTimings* const timings,
-                    const CanardSTM32IfaceMode iface_mode);
+int16_t canardSTM32Init(const CanardSTM32CANTimings* const timings,
+                        const CanardSTM32IfaceMode iface_mode);
 
 /**
  * Pushes one frame into the TX buffer, if there is space.
@@ -140,7 +140,7 @@ int canardSTM32Init(const CanardSTM32CANTimings* const timings,
  * @retval      0               No space in the buffer
  * @retval      negative        Error
  */
-int canardSTM32Transmit(const CanardCANFrame* const frame);
+int16_t canardSTM32Transmit(const CanardCANFrame* const frame);
 
 /**
  * Reads one frame from the hardware RX FIFO, unless all FIFO are empty.
@@ -150,7 +150,7 @@ int canardSTM32Transmit(const CanardCANFrame* const frame);
  * @retval      0               The buffer is empty
  * @retval      negative        Error
  */
-int canardSTM32Receive(CanardCANFrame* const out_frame);
+int16_t canardSTM32Receive(CanardCANFrame* const out_frame);
 
 /**
  * Sets up acceptance filters according to the provided list of ID and masks.
@@ -163,11 +163,11 @@ int canardSTM32Receive(CanardCANFrame* const out_frame);
  * @retval      0               Success
  * @retval      negative        Error
  */
-int canardSTM32ConfigureAcceptanceFilters(const CanardSTM32AcceptanceFilterConfiguration* const filter_configs,
-                                          const unsigned num_filter_configs);
+int16_t canardSTM32ConfigureAcceptanceFilters(const CanardSTM32AcceptanceFilterConfiguration* const filter_configs,
+                                              const uint8_t num_filter_configs);
 
 /**
- * Returns the runnning interface statistics.
+ * Returns the running interface statistics.
  */
 CanardSTM32Stats canardSTM32GetStats(void);
 
@@ -187,9 +187,9 @@ CanardSTM32Stats canardSTM32GetStats(void);
  * @retval negative     Solution could not be found for the provided inputs.
  */
 static inline
-int canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
-                                 const uint32_t target_bitrate,
-                                 CanardSTM32CANTimings* const out_timings)
+int16_t canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
+                                     const uint32_t target_bitrate,
+                                     CanardSTM32CANTimings* const out_timings)
 {
     if (target_bitrate < 1000)
     {
@@ -202,8 +202,8 @@ int canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
     /*
      * Hardware configuration
      */
-    static const int MaxBS1 = 16;
-    static const int MaxBS2 = 8;
+    static const uint8_t MaxBS1 = 16;
+    static const uint8_t MaxBS2 = 8;
 
     /*
      * Ref. "Automatic Baudrate Detection in CANopen Networks", U. Koppe, MicroControl GmbH & Co. KG
@@ -216,10 +216,10 @@ int canardSTM32ComputeCANTimings(const uint32_t peripheral_clock_rate,
      *   250  kbps      16      17
      *   125  kbps      16      17
      */
-    const int max_quanta_per_bit = (target_bitrate >= 1000000) ? 10 : 17;
+    const uint8_t max_quanta_per_bit = (uint8_t)((target_bitrate >= 1000000) ? 10 : 17);
     CANARD_ASSERT(max_quanta_per_bit <= (MaxBS1 + MaxBS2));
 
-    static const int MaxSamplePointLocationPermill = 900;
+    static const uint16_t MaxSamplePointLocationPermill = 900;
 
     /*
      * Computing (prescaler * BS):

--- a/tests/demo.c
+++ b/tests/demo.c
@@ -366,7 +366,7 @@ static void processTxRxOnce(SocketCANInstance* socketcan, int32_t timeout_msec)
     // Transmitting
     for (const CanardCANFrame* txf = NULL; (txf = canardPeekTxQueue(&canard)) != NULL;)
     {
-        const int32_t tx_res = socketcanTransmit(socketcan, txf, 0);
+        const int16_t tx_res = socketcanTransmit(socketcan, txf, 0);
         if (tx_res < 0)         // Failure - drop the frame and report
         {
             canardPopTxQueue(&canard);

--- a/tests/demo.c
+++ b/tests/demo.c
@@ -52,7 +52,6 @@
 
 #define UNIQUE_ID_LENGTH_BYTES                                      16
 
-
 /*
  * Library instance.
  * In simple applications it makes sense to make it static, but it is not necessary.
@@ -95,7 +94,7 @@ static float getRandomFloat(void)
     if (!initialized)                   // This is not thread safe, but a race condition here is not harmful.
     {
         initialized = true;
-        srand((unsigned)time(NULL));
+        srand((uint32_t) time(NULL));
     }
     // coverity[dont_call]
     return (float)rand() / (float)RAND_MAX;
@@ -163,7 +162,7 @@ static void onTransferReceived(CanardInstance* ins,
         }
 
         // Copying the unique ID from the message
-        static const unsigned UniqueIDBitOffset = 8;
+        static const uint8_t UniqueIDBitOffset = 8;
         uint8_t received_unique_id[UNIQUE_ID_LENGTH_BYTES];
         uint8_t received_unique_id_len = 0;
         for (; received_unique_id_len < (transfer->payload_len - (UniqueIDBitOffset / 8U)); received_unique_id_len++)
@@ -181,7 +180,7 @@ static void onTransferReceived(CanardInstance* ins,
         if (memcmp(received_unique_id, my_unique_id, received_unique_id_len) != 0)
         {
             printf("Mismatching allocation response from %d:", transfer->source_node_id);
-            for (int i = 0; i < received_unique_id_len; i++)
+            for (uint8_t i = 0; i < received_unique_id_len; i++)
             {
                 printf(" %02x/%02x", received_unique_id[i], my_unique_id[i]);
             }
@@ -245,15 +244,15 @@ static void onTransferReceived(CanardInstance* ins,
         /*
          * Transmitting; in this case we don't have to release the payload because it's empty anyway.
          */
-        const int resp_res = canardRequestOrRespond(ins,
-                                                    transfer->source_node_id,
-                                                    UAVCAN_GET_NODE_INFO_DATA_TYPE_SIGNATURE,
-                                                    UAVCAN_GET_NODE_INFO_DATA_TYPE_ID,
-                                                    &transfer->transfer_id,
-                                                    transfer->priority,
-                                                    CanardResponse,
-                                                    &buffer[0],
-                                                    (uint16_t)total_size);
+        const int16_t resp_res = canardRequestOrRespond(ins,
+                                                        transfer->source_node_id,
+                                                        UAVCAN_GET_NODE_INFO_DATA_TYPE_SIGNATURE,
+                                                        UAVCAN_GET_NODE_INFO_DATA_TYPE_ID,
+                                                        &transfer->transfer_id,
+                                                        transfer->priority,
+                                                        CanardResponse,
+                                                        &buffer[0],
+                                                        (uint16_t)total_size);
         if (resp_res <= 0)
         {
             (void)fprintf(stderr, "Could not respond to GetNodeInfo; error %d\n", resp_res);
@@ -318,7 +317,7 @@ static void process1HzTasks(uint64_t timestamp_usec)
      */
     {
         const CanardPoolAllocatorStatistics stats = canardGetPoolAllocatorStatistics(&canard);
-        const unsigned peak_percent = 100U * stats.peak_usage_blocks / stats.capacity_blocks;
+        const uint16_t peak_percent = (uint16_t)(100U * stats.peak_usage_blocks / stats.capacity_blocks);
 
         printf("Memory pool stats: capacity %u blocks, usage %u blocks, peak usage %u blocks (%u%%)\n",
                stats.capacity_blocks, stats.current_usage_blocks, stats.peak_usage_blocks, peak_percent);
@@ -340,11 +339,15 @@ static void process1HzTasks(uint64_t timestamp_usec)
         uint8_t buffer[UAVCAN_NODE_STATUS_MESSAGE_SIZE];
         makeNodeStatusMessage(buffer);
 
-        static uint8_t transfer_id;
+        static uint8_t transfer_id;  // Note that the transfer ID variable MUST BE STATIC (or heap-allocated)!
 
-        const int bc_res = canardBroadcast(&canard, UAVCAN_NODE_STATUS_DATA_TYPE_SIGNATURE,
-                                           UAVCAN_NODE_STATUS_DATA_TYPE_ID, &transfer_id, CANARD_TRANSFER_PRIORITY_LOW,
-                                           buffer, UAVCAN_NODE_STATUS_MESSAGE_SIZE);
+        const int16_t bc_res = canardBroadcast(&canard,
+                                               UAVCAN_NODE_STATUS_DATA_TYPE_SIGNATURE,
+                                               UAVCAN_NODE_STATUS_DATA_TYPE_ID,
+                                               &transfer_id,
+                                               CANARD_TRANSFER_PRIORITY_LOW,
+                                               buffer,
+                                               UAVCAN_NODE_STATUS_MESSAGE_SIZE);
         if (bc_res <= 0)
         {
             (void)fprintf(stderr, "Could not broadcast node status; error %d\n", bc_res);
@@ -358,12 +361,12 @@ static void process1HzTasks(uint64_t timestamp_usec)
 /**
  * Transmits all frames from the TX queue, receives up to one frame.
  */
-static void processTxRxOnce(SocketCANInstance* socketcan, int timeout_msec)
+static void processTxRxOnce(SocketCANInstance* socketcan, int32_t timeout_msec)
 {
     // Transmitting
     for (const CanardCANFrame* txf = NULL; (txf = canardPeekTxQueue(&canard)) != NULL;)
     {
-        const int tx_res = socketcanTransmit(socketcan, txf, 0);
+        const int32_t tx_res = socketcanTransmit(socketcan, txf, 0);
         if (tx_res < 0)         // Failure - drop the frame and report
         {
             canardPopTxQueue(&canard);
@@ -382,7 +385,7 @@ static void processTxRxOnce(SocketCANInstance* socketcan, int timeout_msec)
     // Receiving
     CanardCANFrame rx_frame;
     const uint64_t timestamp = getMonotonicTimestampUSec();
-    const int rx_res = socketcanReceive(socketcan, &rx_frame, timeout_msec);
+    const int16_t rx_res = socketcanReceive(socketcan, &rx_frame, timeout_msec);
     if (rx_res < 0)             // Failure - report
     {
         (void)fprintf(stderr, "Receive error %d, errno '%s'\n", rx_res, strerror(errno));
@@ -414,7 +417,7 @@ int main(int argc, char** argv)
      */
     SocketCANInstance socketcan;
     const char* const can_iface_name = argv[1];
-    int res = socketcanInit(&socketcan, can_iface_name);
+    int16_t res = socketcanInit(&socketcan, can_iface_name);
     if (res < 0)
     {
         (void)fprintf(stderr, "Failed to open CAN iface '%s'\n", can_iface_name);
@@ -483,13 +486,13 @@ int main(int argc, char** argv)
         memmove(&allocation_request[1], &my_unique_id[node_id_allocation_unique_id_offset], uid_size);
 
         // Broadcasting the request
-        const int bcast_res = canardBroadcast(&canard,
-                                              UAVCAN_NODE_ID_ALLOCATION_DATA_TYPE_SIGNATURE,
-                                              UAVCAN_NODE_ID_ALLOCATION_DATA_TYPE_ID,
-                                              &node_id_allocation_transfer_id,
-                                              CANARD_TRANSFER_PRIORITY_LOW,
-                                              &allocation_request[0],
-                                              (uint16_t) (uid_size + 1));
+        const int16_t bcast_res = canardBroadcast(&canard,
+                                                  UAVCAN_NODE_ID_ALLOCATION_DATA_TYPE_SIGNATURE,
+                                                  UAVCAN_NODE_ID_ALLOCATION_DATA_TYPE_ID,
+                                                  &node_id_allocation_transfer_id,
+                                                  CANARD_TRANSFER_PRIORITY_LOW,
+                                                  &allocation_request[0],
+                                                  (uint16_t) (uid_size + 1));
         if (bcast_res < 0)
         {
             (void)fprintf(stderr, "Could not broadcast dynamic node ID allocation request; error %d\n", bcast_res);


### PR DESCRIPTION
This is the PR that I advertised here https://github.com/UAVCAN/libcanard/pull/48