### PR TITLE
Added constants for length of arrays in header files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ cmake-build-*/
 
 # Generated files
 dsdlc_generated/
+
+# Pycache
+__pycache__/

--- a/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
@@ -59,6 +59,16 @@ ${line}
 #define ${'%-60s %10s' % (t.macro_name + '_' + a.name, a.init_expression, )} // ${a.init_expression}
     % endfor
 
+    % for a in fields:
+        %if a.type_category == t.CATEGORY_ARRAY
+            %if a.dynamic_array == True
+#define ${'%-80s' % (t.macro_name + service + '_' + a.name.upper() + '_MAX_LENGTH')} ${a.type.max_size}
+            %else
+#define ${'%-80s' % (t.macro_name + service + '_' + a.name.upper() + '_LENGTH')} ${a.type.max_size}  
+            %endif
+        %endif
+    % endfor
+
   %if union
 typedef enum
 {


### PR DESCRIPTION
#58 Constants for lengths of arrays are now generated. 
To distinguish between constants for dynamic and static arrays, different suffixes are used.
For dynamic arrays, the constants will be suffixed with "_MAX_LENGTH", while for static arrays "_LENGTH" is used.