### PR TITLE
Changed from unnamed to named structs in DSDL compiling…

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -66,29 +66,29 @@ uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint3
                     %if f.bitlen < 8
     ${f.array_max_size_bit_len}
     //  - Add array length, last item, but bitlen < 8.
-    canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '_len'))});
+    canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
     offset += ${f.array_max_size_bit_len};
                     %else
     if (! root_item)
     {
         // - Add array length
-        canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '_len'))});
+        canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
         offset += ${f.array_max_size_bit_len};
     }
                     %endif
                 %else
     // - Add array length
-    canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '_len'))});
+    canardEncodeScalar(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
     offset += ${f.array_max_size_bit_len};
                 %endif
 
     // - Add array items
-    for (c = 0; c < source->${'%s' % ((f.name + '_len'))}; c++)
+    for (c = 0; c < source->${'%s' % ((f.name + '.len'))}; c++)
     {
                 %if f.cpp_type_category == t.CATEGORY_COMPOUND:
         offset += ${f.cpp_type}_encode_internal((void*)&source->${f.name}[c], msg_buf, offset, 0);
                 %else
-        canardEncodeScalar(msg_buf, offset, ${f.bitlen}, (void*)(source->${f.name} + c)); // ${f.max_size}
+        canardEncodeScalar(msg_buf, offset, ${f.bitlen}, (void*)(source->${'%s' % ((f.name + '.data'))} + c));// ${f.max_size}
         offset += ${f.bitlen};
                 %endif
     }
@@ -203,12 +203,12 @@ int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t 
     if (payload_len && tao == CANARD_INTERNAL_ENABLE_TAO)
     {
         //  - Calculate Array length from MSG length
-        dest->${'%s' % ((f.name + '_len'))} = ((payload_len * 8) - offset ) / ${f.bitlen}; // ${f.bitlen} bit array item size
+        dest->${'%s' % ((f.name + '.len'))} = ((payload_len * 8) - offset ) / ${f.bitlen}; // ${f.bitlen} bit array item size
     }
     else
     {
         // - Array length ${f.array_max_size_bit_len} bits
-        ret = canardDecodeScalar(transfer, offset, ${f.array_max_size_bit_len}, false, (void*)&dest->${'%s' % ((f.name + '_len'))}); // ${f.max_size}
+        ret = canardDecodeScalar(transfer, offset, ${f.array_max_size_bit_len}, false, (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
         if (ret != ${f.array_max_size_bit_len})
         {
             goto ${type_name}_error_exit;
@@ -216,7 +216,7 @@ int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t 
         offset += ${f.array_max_size_bit_len};
     }
                     %else
-    ret = canardDecodeScalar(transfer, offset, ${f.array_max_size_bit_len}, false, (void*)&dest->${'%s' % ((f.name + '_len'))}); // ${f.max_size}
+    ret = canardDecodeScalar(transfer, offset, ${f.array_max_size_bit_len}, false, (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
     if (ret != ${f.array_max_size_bit_len})
     {
         goto ${type_name}_error_exit;
@@ -236,10 +236,10 @@ int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t 
     //  - Get Array
     if (dyn_arr_buf)
     {
-        dest->${f.name} = (${f.cpp_type}*)*dyn_arr_buf;
+        dest->${'%s' % ((f.name + '.data'))} = (${f.cpp_type}*)*dyn_arr_buf;
     }
 
-    for (c = 0; c < dest->${'%s' % ((f.name + '_len'))}; c++)
+    for (c = 0; c < dest->${'%s' % ((f.name + '.len'))}; c++)
     {
                     %if f.cpp_type_category == t.CATEGORY_COMPOUND:
         offset += ${f.cpp_type}_decode_internal(transfer, 0, (void*)&dest->${f.name}[c], dyn_arr_buf, offset, tao);

--- a/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
@@ -94,12 +94,12 @@ typedef struct
     struct
     {
                 %if a.max_array_elements > 255
-        ${'uint16_t    %-26s // %s' % ((a.name + '_len;'), 'Dynamic array length')}
+        ${'uint16_t    %-26s // %s' % (('len;'), 'Dynamic array length')}
                 %else
-        ${'uint8_t    %-26s // %s' % ((a.name + '_len;'), 'Dynamic array length')}
+        ${'uint8_t    %-26s // %s' % (('len;'), 'Dynamic array length')}
                 %endif
-        ${'%-10s %-26s // %s' % ((a.cpp_type + '*'), (a.name + ';'), a.cpp_type_comment, )}
-    };
+        ${'%-10s %-26s // %s' % ((a.cpp_type + '*'), ('data;'), a.cpp_type_comment, )}
+    } ${a.name};
             %else
     ${'%-10s %-30s // %s' % (a.cpp_type, (a.name + a.post_cpp_type + ';'), a.cpp_type_comment, )}
             %endif


### PR DESCRIPTION
#59. Changed from unnamed to named structs to prevent errors during compiling with c99 and -pedantic.

This PR implements the first proposal by Pavel. Dynamic arrays will now be created as a named struct, with the same name as the array. this inner struct contains two elements - len and data, which holds the length and the data on the dynamic array.
```c
typedef struct
{
    uavcan_protocol_NodeStatus status;
    uavcan_protocol_SoftwareVersion software_version;
    uavcan_protocol_HardwareVersion hardware_version;
    struct
    {
        uint8_t    len;
        uint8_t*   data;
    } name;
} uavcan_protocol_GetNodeInfoResponse;
```
