### PR TITLE
Fix issue with service constants in dsdl compiler

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
@@ -56,7 +56,7 @@ ${line}
 
 // Constants
     % for a in constants:
-#define ${'%-60s %10s' % (t.macro_name + '_' + a.name, a.init_expression, )} // ${a.init_expression}
+#define ${'%-60s %10s' % (t.macro_name + service + '_' + a.name, a.init_expression, )} // ${a.init_expression}
     % endfor
 
     % for a in fields:


### PR DESCRIPTION
If two constants in a service message have the same name, the first one is lost (redefined by the second one)
This path prefix the constants with REQUEST or RESPONSE like any other fields.


--
Found with the ReportBackSoldier service of libuavcan test files