### PR TITLE
Create separate header file for defining the build configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ and you're ready to roll.
 Also you may want to use one of the available drivers for various CAN backends
 that are distributed with Libcanard - check out the `drivers/` directory to find out more.
 
+If you wish to override some of the default options, e.g., assert macros' definition, use the `-D CANARD_ENABLE_CUSTOM_BUILD_CONFIG` flag and provide your implementation in a file named `canard_build_config.h`. 
+
 Example for Make:
 
 ```make

--- a/canard.h
+++ b/canard.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 UAVCAN Team
+ * Copyright (c) 2016-2018 UAVCAN Team
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,11 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <assert.h>
+
+/// Build configuration header. Use it to provide your overrides.
+#ifdef CANARD_ENABLE_CUSTOM_BUILD_CONFIG
+# include "canard_build_config.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The option is given to the user of providing the `canard_build_config.h` header file with custom overrides; this is enabled by defining the `CANARD_ENABLE_CUSTOM_BUILD_CONFIG ` flag.