### PR TITLE
dsdlc_compiler: fixed building of headers with C++

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -124,7 +124,7 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
         %elif f.type_category == t.CATEGORY_COMPOUND:
 
     // Compound
-    offset = ${f.cpp_type}_encode_internal((void*)&source->${f.name}, msg_buf, offset, 0);
+    offset = ${f.cpp_type}_encode_internal(&source->${f.name}, msg_buf, offset, 0);
         %elif f.type_category == t.CATEGORY_PRIMITIVE and f.cpp_type == "float" and f.bitlen == 16:
 
     // float16 special handling
@@ -323,7 +323,7 @@ int32_t ${type_name}_decode_internal(
         %elif f.type_category == t.CATEGORY_COMPOUND:
 
     // Compound
-    offset = ${f.cpp_type}_decode_internal(transfer, 0, (void*)&dest->${f.name}, dyn_arr_buf, offset, tao);
+    offset = ${f.cpp_type}_decode_internal(transfer, 0, &dest->${f.name}, dyn_arr_buf, offset, tao);
     if (offset < 0)
     {
         ret = offset;


### PR DESCRIPTION
this removes the void* cast when calling encode_internal and
decode_internal for compounts. The void* cast causes a -fpermissive
error when built with C++