### PR TITLE
dsdl_compiler: removed non-TAO v0 support

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -18,9 +18,6 @@
 #define CANARD_INTERNAL_SATURATE_UNSIGNED(x, max) ( ((x) > max) ? max : (x) );
 #endif
 
-#define CANARD_INTERNAL_ENABLE_TAO  ((uint8_t) 1)
-#define CANARD_INTERNAL_DISABLE_TAO ((uint8_t) 0)
-
 #if defined(__GNUC__)
 # define CANARD_MAYBE_UNUSED(x) x __attribute__((unused))
 #else
@@ -179,7 +176,6 @@ uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf)
   *                     ${type_name} dyn memory will point to dyn_arr_buf memory.
   *                     NULL will ignore dynamic arrays decoding.
   * @param offset: Call with 0, bit offset to msg storage
-  * @param tao: is tail array optimization used
   * @retval offset or ERROR value if < 0
   */
 int32_t ${type_name}_decode_internal(
@@ -187,8 +183,7 @@ int32_t ${type_name}_decode_internal(
   uint16_t CANARD_MAYBE_UNUSED(payload_len),
   ${type_name}* dest,
   uint8_t** CANARD_MAYBE_UNUSED(dyn_arr_buf),
-  int32_t offset,
-  uint8_t CANARD_MAYBE_UNUSED(tao))
+  int32_t offset)
 {
     int32_t ret = 0;
     %if has_array
@@ -226,7 +221,7 @@ int32_t ${type_name}_decode_internal(
                 %if f.last_item
                     %if f.bitlen > 7
     //  - Last item in struct & Root item & (Array Size > 8 bit), tail array optimization
-    if (payload_len && tao == CANARD_INTERNAL_ENABLE_TAO)
+    if (payload_len)
     {
         //  - Calculate Array length from MSG length
         dest->${'%s' % ((f.name + '.len'))} = ((payload_len * 8) - offset ) / ${f.bitlen}; // ${f.bitlen} bit array item size
@@ -284,8 +279,7 @@ int32_t ${type_name}_decode_internal(
                                                 0,
                                                 (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
                                                 dyn_arr_buf,
-                                                offset,
-                                                tao);
+                                                offset);
                     %else
         if (dyn_arr_buf)
         {
@@ -323,7 +317,7 @@ int32_t ${type_name}_decode_internal(
         %elif f.type_category == t.CATEGORY_COMPOUND:
 
     // Compound
-    offset = ${f.cpp_type}_decode_internal(transfer, 0, &dest->${f.name}, dyn_arr_buf, offset, tao);
+    offset = ${f.cpp_type}_decode_internal(transfer, 0, &dest->${f.name}, dyn_arr_buf, offset);
     if (offset < 0)
     {
         ret = offset;
@@ -388,33 +382,13 @@ int32_t ${type_name}_decode(const CanardRxTransfer* transfer,
     const int32_t offset = 0;
     int32_t ret = 0;
 
-    /* Backward compatibility support for removing TAO
-     *  - first try to decode with TAO DISABLED
-     *  - if it fails fall back to TAO ENABLED
-     */
-    uint8_t tao = CANARD_INTERNAL_DISABLE_TAO;
-
-    while (1)
+    // Clear the destination struct
+    for (uint32_t c = 0; c < sizeof(${type_name}); c++)
     {
-        // Clear the destination struct
-        for (uint32_t c = 0; c < sizeof(${type_name}); c++)
-        {
-            ((uint8_t*)dest)[c] = 0x00;
-        }
-
-        ret = ${type_name}_decode_internal(transfer, payload_len, dest, dyn_arr_buf, offset, tao);
-
-        if (ret >= 0)
-        {
-            break;
-        }
-
-        if (tao == CANARD_INTERNAL_ENABLE_TAO)
-        {
-            break;
-        }
-        tao = CANARD_INTERNAL_ENABLE_TAO;
+        ((uint8_t*)dest)[c] = 0x00;
     }
+
+    ret = ${type_name}_decode_internal(transfer, payload_len, dest, dyn_arr_buf, offset);
 
     return ret;
 }
@@ -436,8 +410,7 @@ int32_t ${type_name}_decode_internal(const CanardRxTransfer* CANARD_MAYBE_UNUSED
   uint16_t CANARD_MAYBE_UNUSED(payload_len),
   ${type_name}* CANARD_MAYBE_UNUSED(dest),
   uint8_t** CANARD_MAYBE_UNUSED(dyn_arr_buf),
-  int32_t offset,
-  uint8_t CANARD_MAYBE_UNUSED(tao))
+  int32_t offset)
 {
     return offset;
 }

--- a/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
@@ -120,7 +120,7 @@ typedef struct
 @!storage_class!@int32_t ${type_name}_decode(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf);
 
 @!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset, uint8_t root_item);
-@!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset, uint8_t tao);
+@!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset);
  %else
 typedef struct
 {
@@ -129,7 +129,7 @@ typedef struct
 @!storage_class!@uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf);
 @!storage_class!@int32_t ${type_name}_decode(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf);
 @!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset, uint8_t root_item);
-@!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset, uint8_t tao);
+@!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset);
 
  %endif
 <!--(end)-->


### PR DESCRIPTION
the v0 non-TAO support didn't work correctly any way, it can get false matches which causes incorrect parsing
