### PR TITLE
Error handling in RX state machine + tests

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -248,7 +248,7 @@ void canardPopTxQueue(CanardInstance* ins)
     freeBlock(&ins->allocator, item);
 }
 
-void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec)
+CanardError canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec)
 {
     const CanardTransferType transfer_type = extractTransferType(frame->id);
     const uint8_t destination_node_id = (transfer_type == CanardTransferTypeBroadcast) ?
@@ -1124,7 +1124,7 @@ CANARD_INTERNAL CanardRxState* traverseRxStates(CanardInstance* ins, uint32_t tr
     if (states == NULL) // initialize CanardRxStates
     {
         states = createRxState(&ins->allocator, transfer_descriptor);
-        
+
         if(states == NULL)
         {
             return NULL;

--- a/canard.c
+++ b/canard.c
@@ -262,13 +262,13 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         (frame->id & CANARD_CAN_FRAME_ERR) != 0 ||
         (frame->data_len < 1))
     {
-        return;     // Unsupported frame, not UAVCAN - ignore
+        return -CANARD_ERROR_RX_INCOMPATIBLE_PACKET;     // Unsupported frame, not UAVCAN - ignore
     }
 
     if (transfer_type != CanardTransferTypeBroadcast &&
         destination_node_id != canardGetLocalNodeID(ins))
     {
-        return;     // Address mismatch
+        return -CANARD_ERROR_RX_WRONG_ADDRESS;     // Address mismatch
     }
 
     const uint8_t priority = PRIORITY_FROM_ID(frame->id);
@@ -291,14 +291,14 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
 
             if(rx_state == NULL)
             {
-                return; // No allocator room for this frame
+                return -CANARD_ERROR_OUT_OF_MEMORY; // No allocator room for this frame
             }
 
             rx_state->calculated_crc = crcAddSignature(0xFFFFU, data_type_signature);
         }
         else
         {
-            return;     // The application doesn't want this transfer
+            return -CANARD_ERROR_RX_NOT_WANTED;     // The application doesn't want this transfer
         }
     }
     else
@@ -307,7 +307,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
 
         if (rx_state == NULL)
         {
-            return;
+            return -CANARD_ERROR_RX_NO_STATE;
         }
     }
 
@@ -333,7 +333,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         if (!IS_START_OF_TRANSFER(tail_byte)) // missed the first frame
         {
             rx_state->transfer_id++;
-            return;
+            return -CANARD_ERROR_RX_MISSED_START;
         }
     }
 
@@ -354,24 +354,24 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         ins->on_reception(ins, &rx_transfer);
 
         prepareForNextTransfer(rx_state);
-        return;
+        return CANARD_OK;
     }
 
     if (TOGGLE_BIT(tail_byte) != rx_state->next_toggle)
     {
-        return; // wrong toggle
+        return -CANARD_ERROR_RX_WRONG_TOGGLE; // wrong toggle
     }
 
     if (TRANSFER_ID_FROM_TAIL_BYTE(tail_byte) != rx_state->transfer_id)
     {
-        return; // unexpected tid
+        return -CANARD_ERROR_RX_UNEXPECTED_TID; // unexpected tid
     }
 
     if (IS_START_OF_TRANSFER(tail_byte) && !IS_END_OF_TRANSFER(tail_byte))      // Beginning of multi frame transfer
     {
         if (frame->data_len <= 3)
         {
-            return;     // Not enough data
+            return -CANARD_ERROR_RX_SHORT_FRAME;     // Not enough data
         }
 
         // take off the crc and store the payload
@@ -382,7 +382,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         {
             releaseStatePayload(ins, rx_state);
             prepareForNextTransfer(rx_state);
-            return;
+            return ret;
         }
         rx_state->payload_crc = (uint16_t)(((uint16_t) frame->data[0]) | (uint16_t)((uint16_t) frame->data[1] << 8U));
         rx_state->calculated_crc = crcAdd((uint16_t)rx_state->calculated_crc,
@@ -396,7 +396,7 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         {
             releaseStatePayload(ins, rx_state);
             prepareForNextTransfer(rx_state);
-            return;
+            return ret;
         }
         rx_state->calculated_crc = crcAdd((uint16_t)rx_state->calculated_crc,
                                           frame->data, (uint8_t)(frame->data_len - 1));
@@ -464,14 +464,18 @@ void canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint6
         {
             ins->on_reception(ins, &rx_transfer);
         }
+        else{
+            return -CANARD_ERROR_RX_BAD_CRC;
+        }
 
         // Making sure the payload is released even if the application didn't bother with it
         canardReleaseRxTransferPayload(ins, &rx_transfer);
         prepareForNextTransfer(rx_state);
-        return;
+        return CANARD_OK;
     }
 
     rx_state->next_toggle = rx_state->next_toggle ? 0 : 1;
+    return CANARD_OK;
 }
 
 void canardCleanupStaleTransfers(CanardInstance* ins, uint64_t current_time_usec)

--- a/canard.h
+++ b/canard.h
@@ -65,12 +65,24 @@ extern "C" {
 #endif
 
 /// Error code definitions; inverse of these values may be returned from API calls.
-#define CANARD_OK                                   0
-// Value 1 is omitted intentionally, since -1 is often used in 3rd party code
-#define CANARD_ERROR_INVALID_ARGUMENT               2
-#define CANARD_ERROR_OUT_OF_MEMORY                  3
-#define CANARD_ERROR_NODE_ID_NOT_SET                4
-#define CANARD_ERROR_INTERNAL                       9
+typedef enum{
+    CANARD_OK                                      = 0,
+// Value 1 is omitted intentionally, since -1 i    =s often used in 3rd party code
+    CANARD_ERROR_INVALID_ARGUMENT                  = 2,
+    CANARD_ERROR_OUT_OF_MEMORY                     = 3,
+    CANARD_ERROR_NODE_ID_NOT_SET                   = 4,
+    CANARD_ERROR_INTERNAL                          = 9,
+// Error codes for Rx handler    =
+    CANARD_ERROR_RX_INCOMPATIBLE_PACKET            = 10,
+    CANARD_ERROR_RX_WRONG_ADDRESS                  = 11,
+    CANARD_ERROR_RX_NOT_WANTED                     = 12,
+    CANARD_ERROR_RX_NO_STATE                       = 13,
+    CANARD_ERROR_RX_MISSED_START                   = 14,
+    CANARD_ERROR_RX_WRONG_TOGGLE                   = 15,
+    CANARD_ERROR_RX_UNEXPECTED_TID                 = 16,
+    CANARD_ERROR_RX_SHORT_FRAME                    = 17,
+    CANARD_ERROR_RX_BAD_CRC                        = 18
+}CanardError;
 
 /// The size of a memory block in bytes.
 #define CANARD_MEM_BLOCK_SIZE                       32U
@@ -417,8 +429,10 @@ void canardPopTxQueue(CanardInstance* ins);
 /**
  * Processes a received CAN frame with a timestamp.
  * The application will call this function when it receives a new frame from the CAN bus.
+ * 
+ * Return value will report any errors in decoding packets.
  */
-void canardHandleRxFrame(CanardInstance* ins,
+int16_t canardHandleRxFrame(CanardInstance* ins,
                          const CanardCANFrame* frame,
                          uint64_t timestamp_usec);
 

--- a/canard.h
+++ b/canard.h
@@ -429,10 +429,10 @@ void canardPopTxQueue(CanardInstance* ins);
 /**
  * Processes a received CAN frame with a timestamp.
  * The application will call this function when it receives a new frame from the CAN bus.
- * 
+ *
  * Return value will report any errors in decoding packets.
  */
-int16_t canardHandleRxFrame(CanardInstance* ins,
+CanardError canardHandleRxFrame(CanardInstance* ins,
                          const CanardCANFrame* frame,
                          uint64_t timestamp_usec);
 

--- a/tests/test_rxerr.cpp
+++ b/tests/test_rxerr.cpp
@@ -1,0 +1,345 @@
+/*
+ * This demo application is distributed under the terms of CC0 (public domain dedication).
+ * More info: https://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+// This is needed to enable necessary declarations in sys/
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
+#include <catch.hpp>
+#include <canard.h>
+
+static bool shouldAccept = true;
+
+/**
+ * This callback is invoked by the library when a new message or request or response is received.
+ */
+static void onTransferReceived(CanardInstance* ins,
+                               CanardRxTransfer* transfer)
+{
+    (void)ins;
+    (void)transfer;
+}
+
+static bool shouldAcceptTransfer(const CanardInstance* ins,
+                                 uint64_t* out_data_type_signature,
+                                 uint16_t data_type_id,
+                                 CanardTransferType transfer_type,
+                                 uint8_t source_node_id)
+{
+    (void)ins;
+    (void)out_data_type_signature;
+    (void)data_type_id;
+    (void)transfer_type;
+    (void)source_node_id;
+    return shouldAccept;
+}
+
+TEST_CASE("canardHandleRxFrame incompatible packet handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    //Setup frame data to be single frame transfer
+    frame.data[0] = (1 << 7) | (1 << 6);
+
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    shouldAccept = true;
+
+    //Frame with good RTR/ERR/data_len bad EFF
+    frame.id = 0;
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_INCOMPATIBLE_PACKET == err);
+
+    //Frame with good EFF/ERR/data_len, bad RTR
+    frame.id = 0 | CANARD_CAN_FRAME_RTR | CANARD_CAN_FRAME_EFF;
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_INCOMPATIBLE_PACKET == err);
+
+    //Frame with good EFF/RTR/data_len, bad ERR
+    frame.id = 0 | CANARD_CAN_FRAME_ERR | CANARD_CAN_FRAME_EFF;
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_INCOMPATIBLE_PACKET == err);
+
+    //Frame with good EFF/RTR/ERR, bad data_len
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;
+    frame.data_len = 0;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_INCOMPATIBLE_PACKET == err);
+
+    //Frame with good EFF/RTR/ERR/data_len
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+}
+
+TEST_CASE("canardHandleRxFrame wrong address handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    //Setup frame data to be single frame transfer
+    frame.data[0] = (1 << 7) | (1 << 6);
+
+    //Open canard to accept all transfers with a node ID of 20
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    canardSetLocalNodeID(&canard, 20);
+    shouldAccept = true;
+
+    //Send package with ID 24, should not be wanted
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (24 << 8);                          //Set address to 24
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_WRONG_ADDRESS == err);
+
+    //Send package with ID 20, should be OK
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+}
+
+TEST_CASE("canardHandleRxFrame shouldAccept handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    //Setup frame data to be single frame transfer
+    frame.data[0] = (1 << 7) | (1 << 6);
+
+    //Open canard to accept all transfers with a node ID of 20
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    canardSetLocalNodeID(&canard, 20);
+
+    //Send packet, don't accept
+    shouldAccept = false;
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_NOT_WANTED == err);
+
+    //Send packet, accept
+    shouldAccept = true;
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+}
+
+TEST_CASE("canardHandleRxFrame no state handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    shouldAccept = true;
+
+    //Open canard to accept all transfers with a node ID of 20
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    canardSetLocalNodeID(&canard, 20);
+
+    //Not start or end of packet, should fail
+    frame.data[0] = 0;
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_NO_STATE == err);
+
+    //End of packet, should fail
+    frame.data[0] = (1 << 6);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_NO_STATE == err);
+
+    //1 Frame packet, should pass
+    frame.data[0] = (1 << 7) | (1 << 6);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+    //Send a start packet, should pass
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[7] = (1 << 7) | 1;                   //Use TID 1
+
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+    //Send a middle packet, from the same ID, but don't toggle
+    frame.data[0] = 0 | 1;
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 1;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_WRONG_TOGGLE == err);
+
+    //Send a middle packet, toggle, but use wrong ID
+    frame.data[0] = 0 | 2;
+    frame.data[7] = 0 | 2 | (1<<5);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_UNEXPECTED_TID == err);
+
+    //Send a middle packet, toggle, and use correct ID
+    frame.data[0] = 0 | 1;
+    frame.data[7] = 0 | 1 | (1<<5);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+}
+
+TEST_CASE("canardHandleRxFrame missed start handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    shouldAccept = true;
+
+    //Open canard to accept all transfers with a node ID of 20
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    canardSetLocalNodeID(&canard, 20);
+
+    //Send a start packet, should pass
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[7] = (1 << 7) | 1;                   //Use TID 1
+
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+    //Send a middle packet, toggle, and use correct ID - but timeout
+    frame.data[0] = 0 | 1;
+    frame.data[7] = 0 | 1 | (1<<5);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;
+    err = canardHandleRxFrame(&canard, &frame, 4000000);
+    REQUIRE(-CANARD_ERROR_RX_MISSED_START == err);
+
+    //Send a start packet, should pass
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[7] = (1 << 7) | 1;                   //Use TID 1
+
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+    //Send a middle packet, toggle, and use correct ID - but timestamp 0
+    frame.data[0] = 0 | 1;
+    frame.data[7] = 0 | 1 | (1<<5);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;
+    err = canardHandleRxFrame(&canard, &frame, 0);
+    REQUIRE(-CANARD_ERROR_RX_MISSED_START == err);
+
+    //Send a start packet, should pass
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[7] = (1 << 7) | 1;                   //Use TID 1
+
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(CANARD_OK == err);
+
+    //Send a middle packet, toggle, and use an incorrect TID
+    frame.data[0] = 0 | 3;
+    frame.data[7] = 0 | 3 | (1<<5);
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 8;
+    err = canardHandleRxFrame(&canard, &frame, 0);
+    REQUIRE(-CANARD_ERROR_RX_MISSED_START == err);
+}
+
+TEST_CASE("canardHandleRxFrame short frame handling, Correctness")
+{
+    uint8_t canard_memory_pool[1024];
+    CanardInstance canard;
+    CanardCANFrame frame;
+    CanardError err;
+
+    shouldAccept = true;
+
+    //Open canard to accept all transfers with a node ID of 20
+    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool), onTransferReceived, shouldAcceptTransfer, (void*)&canard);
+    canardSetLocalNodeID(&canard, 20);
+
+    //Send a start packet which is short, should fail
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[1] = (1 << 7) | 1;                   //Use TID 1
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 2;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_SHORT_FRAME == err);
+
+    //Send a start packet which is short, should fail
+    frame.data[0] = (1 << 7) | 1;                   //Use TID 1
+    frame.data[2] = (1 << 7) | 1;                   //Use TID 1
+    frame.id = 0 | CANARD_CAN_FRAME_EFF;            //Set EFF
+    frame.id |= (1 << 7);                           //Set service bit
+    frame.id |= (20 << 8);                          //Set address to 20
+    frame.data_len = 3;                             //Data length MUST be full packet
+    err = canardHandleRxFrame(&canard, &frame, 1);
+    REQUIRE(-CANARD_ERROR_RX_SHORT_FRAME == err);
+
+
+
+}
+
+


### PR DESCRIPTION
I added this locally whilst looking more at libcanard, raising in case this is useful to merge back.

Note - this does change the prototype of canardHandleRxFrame giving it a return type - may break builds that warn on ignored return values.