### PR TITLE
Bugfix priority field position in test

### DIFF
--- a/tests/test_rxerr.cpp
+++ b/tests/test_rxerr.cpp
@@ -26,7 +26,7 @@
 #include <canard.h>
 
 //Independent implementation of ID layout from https://uavcan.org/Specification/4._CAN_bus_transport_layer/
-#define CONSTRUCT_PRIO(prio)        (((prio) & 0x1F) << 23)
+#define CONSTRUCT_PRIO(prio)        (((prio) & 0x1F) << 24)
 #define CONSTRUCT_MTID(mtid)        (((mtid) & 0xFFFF) << 8)
 #define CONSTRUCT_SID(sid)          (((sid)  & 0x7F))
 #define CONSTRUCT_DISC(disc)        (((disc) & 0x3FFF) << 10)


### PR DESCRIPTION
Let's merge this into master then include it in #92 as well.

I didn't bother adding tests for priority different from 0 at this point as the header changes is going into the uavcan v1.0 branch pretty soon anyway and that seemed like a just as good point in time to do it.
