### PR TITLE
[WIP] Multiple transport protocol (CAN-FD) support

### DIFF
--- a/canard_can.c
+++ b/canard_can.c
@@ -1,0 +1,24 @@
+#include "canard.h"
+#include "canard_internals.h"
+#include "canard_can.h"
+
+int16_t canardCANPeekTxQueue(const CanardInstance* ins, CanardCANFrame** frame)
+{
+    if (ins->transport_protocol != CanardTransportProtocolCAN)
+    {
+        return -CANARD_ERROR_INCOMPATIBLE_TRANSPORT_PROTOCOL;
+    }
+
+    return canardPeekTxQueue(ins, (CanardTransportFrame**)frame);
+}
+
+int16_t canardCANHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, uint64_t timestamp_usec)
+{
+    if (ins->transport_protocol != CanardTransportProtocolCAN)
+    {
+        return -CANARD_ERROR_INCOMPATIBLE_TRANSPORT_PROTOCOL;
+    }
+
+    return canardHandleRxFrame(ins, (CanardTransportFrame*)frame, timestamp_usec);
+}
+

--- a/canard_can.h
+++ b/canard_can.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-2018 UAVCAN Team
+ *
+ * Distributed under the MIT License, available in the file LICENSE.
+ *
+ */
+
+#ifndef CANARD_CAN_H
+#define CANARD_CAN_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define CANARD_CAN_FRAME_MAX_DATA_LEN               8U
+
+/**
+ * This data type holds a standard CAN 2.0B data frame with 29-bit ID.
+ */
+typedef struct
+{
+    /**
+     * Refer to the following definitions:
+     *  - CANARD_CAN_FRAME_EFF
+     *  - CANARD_CAN_FRAME_RTR
+     *  - CANARD_CAN_FRAME_ERR
+     */
+    uint32_t id;
+    uint8_t data_len;
+    
+    /* The size of data depends on the transport frame in use */
+    uint8_t data[CANARD_CAN_FRAME_MAX_DATA_LEN];
+} CanardCANFrame;
+
+/**
+ * Returns a pointer to the top priority frame in the TX queue.
+ * Returns NULL if the TX queue is empty.
+ * The application will call this function after canardBroadcast() or canardRequestOrRespond() to transmit generated
+ * frames over the CAN bus.
+ */
+int16_t canardCANPeekTxQueue(const CanardInstance* ins, 
+                             CanardCANFrame** frame);
+
+/**
+ * Processes a received CAN frame with a timestamp.
+ * The application will call this function when it receives a new frame from the CAN bus.
+ *
+ * Return value will report any errors in decoding packets.
+ */
+int16_t canardCANHandleRxFrame(CanardInstance* ins,
+                               const CanardCANFrame* frame,
+                               uint64_t timestamp_usec);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/canard_internals.h
+++ b/canard_internals.h
@@ -93,6 +93,13 @@ CANARD_INTERNAL int16_t enqueueTxFrames(CanardInstance* ins,
                                         const uint8_t* payload,
                                         uint16_t payload_len);
 
+int16_t canardPeekTxQueue(const CanardInstance* ins, 
+                          CanardTransportFrame** frame);
+
+int16_t canardHandleRxFrame(CanardInstance* ins,
+                            const CanardTransportFrame* frame,
+                            uint64_t timestamp_usec);
+
 CANARD_INTERNAL void copyBitArray(const uint8_t* src,
                                   uint32_t src_offset,
                                   uint32_t src_len,

--- a/canard_internals.h
+++ b/canard_internals.h
@@ -133,8 +133,9 @@ CANARD_INTERNAL uint16_t crcAdd(uint16_t crc_val,
  * @param [in] buf_len The number of blocks in buf.
  */
 CANARD_INTERNAL void initPoolAllocator(CanardPoolAllocator* allocator,
-                                       CanardPoolAllocatorBlock* buf,
-                                       uint16_t buf_len);
+                                       size_t block_size,
+                                       void* buf,
+                                       size_t buf_len);
 
 /**
  * Allocates a block from the given pool allocator.

--- a/drivers/socketcan/socketcan.h
+++ b/drivers/socketcan/socketcan.h
@@ -9,6 +9,7 @@
 #define SOCKETCAN_H
 
 #include <canard.h>
+#include <canard_can.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/drivers/stm32/canard_stm32.h
+++ b/drivers/stm32/canard_stm32.h
@@ -10,6 +10,7 @@
 #define CANARD_STM32_H
 
 #include <canard.h>
+#include <canard_can.h>
 #include <string.h>     // NOLINT
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ file(GLOB tests_src
 message(STATUS "Unit test source files: ${tests_src}")
 add_executable(run_tests
                ${tests_src}
+               ../canard_can.c
                ../canard.c)
 target_link_libraries(run_tests
                       pthread)
@@ -55,6 +56,7 @@ exec_program("git"
 
 add_executable(demo
                demo.c
+               ../canard_can.c
                ../canard.c
                ../drivers/socketcan/socketcan.c)
 

--- a/tests/test_init.cpp
+++ b/tests/test_init.cpp
@@ -46,6 +46,7 @@ TEST_CASE("Init, UserReference")
 
     ::CanardInstance ins;
     canardInit(&ins,
+               CanardTransportProtocolCAN,
                memory_arena,
                sizeof(memory_arena),
                &onTransferReceptionMock,

--- a/tests/test_scalar_encoding.cpp
+++ b/tests/test_scalar_encoding.cpp
@@ -112,9 +112,10 @@ TEST_CASE("ScalarDecode, MultiFrame")
     /*
      * Configuring allocator
      */
-    uint8_t buffer[2*32];
+    const uint8_t block_size = 32;
+    uint8_t buffer[2*block_size];
     CanardPoolAllocator allocator;
-    initPoolAllocator(&allocator, 32, &buffer, 2*32);
+    initPoolAllocator(&allocator, block_size, &buffer, sizeof(buffer));
 
     /*
      * Configuring the transfer object
@@ -148,6 +149,7 @@ TEST_CASE("ScalarDecode, MultiFrame")
     transfer.payload_head   = &head[0];
     transfer.payload_middle = middle_a;
     transfer.payload_tail   = &tail[0];
+    transfer.block_size     = block_size;
 
     transfer.payload_len =
         uint16_t(CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE(32) + CANARD_BUFFER_BLOCK_DATA_SIZE(32) * 2 + sizeof(tail));


### PR DESCRIPTION
This is perhaps a bit rough around the edges still. But I would love to get some early feedback on this. Especially from @pavel-kirienko, but also @aasmune and @thirtytwobits if they have the opportunity. 

My following changes and rationale:
 - In order to support multiple transport protocols, differently sized blocks depending on the transport layer was required to avoid being extremely wasteful with memory when using CAN-2.0B.
 - Statically setting the transport protocol and block size was deemed inflexible and not very user friendly. Instead this is set on initialization. 
 - Even though there will be multiple similar functions relating to transport frames, I think an API along the lines of these changes is simple to use correctly after C standards and will work well in practice.

Am I making a mistake by making the transport protocol selection dynamic? If this was a language with generics I would probably use it to implement this. I do feel like the dynamic approach is the least bad in this case.
 
