### PR TITLE
fixed C++ errors and permissions

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/__init__.py
+++ b/dsdl_compiler/libcanard_dsdl_compiler/__init__.py
@@ -28,7 +28,6 @@ except NameError:
 
 OUTPUT_HEADER_FILE_EXTENSION = 'h'
 OUTPUT_CODE_FILE_EXTENSION = 'c'
-OUTPUT_FILE_PERMISSIONS = 0o444  # Read only for all
 HEADER_TEMPLATE_FILENAME = os.path.join(os.path.dirname(__file__), 'data_type_template.tmpl')
 CODE_TEMPLATE_FILENAME = os.path.join(os.path.dirname(__file__), 'code_type_template.tmpl')
 
@@ -151,12 +150,6 @@ def write_generated_data(filename, data, header_only, append_file=False):
             os.remove(filename)
         with open(filename, 'w') as f:
             f.write(data)
-
-    if not header_only or header_only and append_file:
-        try:
-            os.chmod(filename, OUTPUT_FILE_PERMISSIONS)
-        except (OSError, IOError) as ex:
-            logger.warning('Failed to set permissions for %s: %s', pretty_filename(filename), ex)
 
 def expand_to_next_full(size):
     if size <= 8:

--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -96,7 +96,7 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
     for (c = 0; c < source->${'%s' % ((f.name + '.len'))}; c++)
     {
                 %if f.cpp_type_category == t.CATEGORY_COMPOUND:
-        offset += ${f.cpp_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
+        offset += ${f.cpp_type}_encode_internal(&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
                 %else
         canardEncodeScalar(msg_buf,
                            offset,
@@ -277,7 +277,7 @@ int32_t ${type_name}_decode_internal(
                     %if f.cpp_type_category == t.CATEGORY_COMPOUND:
         offset += ${f.cpp_type}_decode_internal(transfer,
                                                 0,
-                                                (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
+                                                &dest->${'%s' % ((f.name + '.data'))}[c],
                                                 dyn_arr_buf,
                                                 offset);
                     %else


### PR DESCRIPTION
This fixes a build error with C++, plus fixes the permissions on generated headers. The permissions matter as otherwise a rebuild fails with permission denied
