### PR TITLE
Fixed the argument order in isPriorityHigher()

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -1021,9 +1021,9 @@ CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator)
 }
 
 /**
- * Returns true if priority of rhs is higher than id
+ * Returns true if priority of id is higher than rhs.
  */
-CANARD_INTERNAL bool isPriorityHigher(uint32_t rhs, uint32_t id)
+CANARD_INTERNAL bool isPriorityHigher(uint32_t id, uint32_t rhs)
 {
     const uint32_t clean_id = id & CANARD_CAN_EXT_ID_MASK;
     const uint32_t rhs_clean_id = rhs & CANARD_CAN_EXT_ID_MASK;

--- a/canard.c
+++ b/canard.c
@@ -1025,42 +1025,42 @@ CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator)
  */
 CANARD_INTERNAL bool isPriorityHigher(uint32_t self, uint32_t other)
 {
-    const uint32_t clean_id = self & CANARD_CAN_EXT_ID_MASK;
-    const uint32_t rhs_clean_id = other & CANARD_CAN_EXT_ID_MASK;
+    const uint32_t self_clean_id = self & CANARD_CAN_EXT_ID_MASK;
+    const uint32_t other_clean_id = other & CANARD_CAN_EXT_ID_MASK;
 
     /*
      * STD vs EXT - if 11 most significant bits are the same, EXT loses.
      */
-    const bool ext = (self & CANARD_CAN_FRAME_EFF) != 0;
-    const bool rhs_ext = (other & CANARD_CAN_FRAME_EFF) != 0;
-    if (ext != rhs_ext)
+    const bool self_ext = (self & CANARD_CAN_FRAME_EFF) != 0;
+    const bool other_ext = (other & CANARD_CAN_FRAME_EFF) != 0;
+    if (self_ext != other_ext)
     {
-        uint32_t arb11 = ext ? (clean_id >> 18U) : clean_id;
-        uint32_t rhs_arb11 = rhs_ext ? (rhs_clean_id >> 18U) : rhs_clean_id;
-        if (arb11 != rhs_arb11)
+        const uint32_t self_arb11 = self_ext ? (self_clean_id >> 18U) : self_clean_id;
+        const uint32_t other_arb11 = other_ext ? (other_clean_id >> 18U) : other_clean_id;
+        if (self_arb11 != other_arb11)
         {
-            return arb11 < rhs_arb11;
+            return self_arb11 < other_arb11;
         }
         else
         {
-            return rhs_ext;
+            return other_ext;
         }
     }
 
     /*
      * RTR vs Data frame - if frame identifiers and frame types are the same, RTR loses.
      */
-    const bool rtr = (self & CANARD_CAN_FRAME_RTR) != 0;
-    const bool rhs_rtr = (other & CANARD_CAN_FRAME_RTR) != 0;
-    if (clean_id == rhs_clean_id && rtr != rhs_rtr)
+    const bool self_rtr = (self & CANARD_CAN_FRAME_RTR) != 0;
+    const bool other_rtr = (other & CANARD_CAN_FRAME_RTR) != 0;
+    if (self_clean_id == other_clean_id && self_rtr != other_rtr)
     {
-        return rhs_rtr;
+        return other_rtr;
     }
 
     /*
      * Plain ID arbitration - greater value loses.
      */
-    return clean_id < rhs_clean_id;
+    return self_clean_id < other_clean_id;
 }
 
 /**

--- a/canard.c
+++ b/canard.c
@@ -1021,18 +1021,18 @@ CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator)
 }
 
 /**
- * Returns true if priority of id is higher than rhs.
+ * Returns true if priority of self is higher than other.
  */
-CANARD_INTERNAL bool isPriorityHigher(uint32_t id, uint32_t rhs)
+CANARD_INTERNAL bool isPriorityHigher(uint32_t self, uint32_t other)
 {
-    const uint32_t clean_id = id & CANARD_CAN_EXT_ID_MASK;
-    const uint32_t rhs_clean_id = rhs & CANARD_CAN_EXT_ID_MASK;
+    const uint32_t clean_id = self & CANARD_CAN_EXT_ID_MASK;
+    const uint32_t rhs_clean_id = other & CANARD_CAN_EXT_ID_MASK;
 
     /*
      * STD vs EXT - if 11 most significant bits are the same, EXT loses.
      */
-    const bool ext = (id & CANARD_CAN_FRAME_EFF) != 0;
-    const bool rhs_ext = (rhs & CANARD_CAN_FRAME_EFF) != 0;
+    const bool ext = (self & CANARD_CAN_FRAME_EFF) != 0;
+    const bool rhs_ext = (other & CANARD_CAN_FRAME_EFF) != 0;
     if (ext != rhs_ext)
     {
         uint32_t arb11 = ext ? (clean_id >> 18U) : clean_id;
@@ -1050,8 +1050,8 @@ CANARD_INTERNAL bool isPriorityHigher(uint32_t id, uint32_t rhs)
     /*
      * RTR vs Data frame - if frame identifiers and frame types are the same, RTR loses.
      */
-    const bool rtr = (id & CANARD_CAN_FRAME_RTR) != 0;
-    const bool rhs_rtr = (rhs & CANARD_CAN_FRAME_RTR) != 0;
+    const bool rtr = (self & CANARD_CAN_FRAME_RTR) != 0;
+    const bool rhs_rtr = (other & CANARD_CAN_FRAME_RTR) != 0;
     if (clean_id == rhs_clean_id && rtr != rhs_rtr)
     {
         return rhs_rtr;

--- a/canard_internals.h
+++ b/canard_internals.h
@@ -70,8 +70,8 @@ CANARD_INTERNAL uint16_t extractDataType(uint32_t id);
 CANARD_INTERNAL void pushTxQueue(CanardInstance* ins,
                                  CanardTxQueueItem* item);
 
-CANARD_INTERNAL bool isPriorityHigher(uint32_t id,
-                                      uint32_t rhs);
+CANARD_INTERNAL bool isPriorityHigher(uint32_t self,
+                                      uint32_t other);
 
 CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator);
 


### PR DESCRIPTION
I've received an email notifying me of this bug. We weren't aware of it because we don't have unit tests here. The TX queue was prioritized improperly because of this issue.

This fix should be cherry-picked into uavcan-v1.0 as well.