### PR TITLE
Removed TAO in serialization code.

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -33,13 +33,11 @@
   * @param source : pointer to source data struct
   * @param msg_buf: pointer to msg storage
   * @param offset: bit offset to msg storage
-  * @param root_item: for detecting if TAO should be used
   * @retval returns offset
   */
 uint32_t ${type_name}_encode_internal(${type_name}* source,
   void* msg_buf,
-  uint32_t offset,
-  uint8_t CANARD_MAYBE_UNUSED(root_item))
+  uint32_t offset)
 {
   %if union
     // Max Union Tag Value
@@ -81,7 +79,7 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
     for (c = 0; c < source->${'%s' % ((f.name + '.len'))}; c++)
     {
                 %if isinstance(f.data_type.element_type, CompoundType)
-        offset += ${f.c_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
+        offset += ${f.c_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset);
                 %else
         canardEncodePrimitive(msg_buf,
                               offset,
@@ -106,7 +104,7 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
         %elif isinstance(f.data_type, CompoundType)
 
     // Compound
-    offset = ${f.c_type}_encode_internal(&source->${f.name}, msg_buf, offset, 0);
+    offset = ${f.c_type}_encode_internal(&source->${f.name}, msg_buf, offset);
         %elif isinstance(f.data_type, FloatType) and f.bitlen == 16:
 
     // float16 special handling
@@ -147,7 +145,7 @@ uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf)
 {
     uint32_t offset = 0;
 
-    offset = ${type_name}_encode_internal(source, msg_buf, offset, 1);
+    offset = ${type_name}_encode_internal(source, msg_buf, offset);
 
     return (offset + 7 ) / 8;
 }
@@ -345,8 +343,7 @@ int32_t ${type_name}_decode(const CanardRxTransfer* transfer,
  %else
 uint32_t ${type_name}_encode_internal(${type_name}* CANARD_MAYBE_UNUSED(source),
   void* CANARD_MAYBE_UNUSED(msg_buf),
-  uint32_t offset,
-  uint8_t CANARD_MAYBE_UNUSED(root_item))
+  uint32_t offset)
 {
     return offset;
 }

--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -72,25 +72,10 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
             %if isinstance(f.data_type, DynamicArrayType)
 
     // Dynamic Array (${f.name})
-                %if f.last_item
-                    %if f.bitlen < 8
-    ${f.array_max_size_bit_len}
-    //  - Add array length, last item, but bitlen < 8.
-    canardEncodePrimitive(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
-    offset += ${f.array_max_size_bit_len};
-                    %else
-    if (! root_item)
-    {
-        // - Add array length
-        canardEncodePrimitive(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
-        offset += ${f.array_max_size_bit_len};
-    }
-                    %endif
-                %else
+
     // - Add array length
     canardEncodePrimitive(msg_buf, offset, ${f.array_max_size_bit_len}, (void*)&source->${'%s' % ((f.name + '.len'))});
     offset += ${f.array_max_size_bit_len};
-                %endif
 
     // - Add array items
     for (c = 0; c < source->${'%s' % ((f.name + '.len'))}; c++)
@@ -99,9 +84,9 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
         offset += ${f.c_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
                 %else
         canardEncodePrimitive(msg_buf,
-                           offset,
-                           ${f.bitlen},
-                           (void*)(source->${'%s' % ((f.name + '.data'))} + c));// ${f.max_size}
+                              offset,
+                              ${f.bitlen},
+                              (void*)(source->${'%s' % ((f.name + '.data'))} + c));// ${f.max_size}
         offset += ${f.bitlen};
                 %endif
     }
@@ -218,53 +203,18 @@ int32_t ${type_name}_decode_internal(
             %if f.dynamic_array == True
 
     // Dynamic Array (${f.name})
-                %if f.last_item
-                    %if f.bitlen > 7
-    //  - Last item in struct & Root item & (Array Size > 8 bit), tail array optimization
-    if (payload_len)
-    {
-        //  - Calculate Array length from MSG length
-        dest->${'%s' % ((f.name + '.len'))} = ((payload_len * 8) - offset ) / ${f.bitlen}; // ${f.bitlen} bit array item size
-    }
-    else
-    {
-        // - Array length ${f.array_max_size_bit_len} bits
-        ret = canardDecodePrimitive(transfer,
-                                 (uint32_t)offset,
-                                 ${f.array_max_size_bit_len},
-                                 false,
-                                 (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
-        if (ret != ${f.array_max_size_bit_len})
-        {
-            goto ${type_name}_error_exit;
-        }
-        offset += ${f.array_max_size_bit_len};
-    }
-                    %else
+    
+    //  - Array length, ${f.array_max_size_bit_len} bits
     ret = canardDecodePrimitive(transfer,
-                             (uint32_t)offset,
-                             ${f.array_max_size_bit_len},
-                             false,
-                             (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
+                                (uint32_t)offset,
+                                ${f.array_max_size_bit_len},
+                                false,
+                                (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
     if (ret != ${f.array_max_size_bit_len})
     {
         goto ${type_name}_error_exit;
     }
     offset += ${f.array_max_size_bit_len};
-                    %endif
-                %else
-    //  - Array length, not last item ${f.array_max_size_bit_len} bits
-    ret = canardDecodePrimitive(transfer,
-                             (uint32_t)offset,
-                             ${f.array_max_size_bit_len},
-                             false,
-                             (void*)&dest->${'%s' % ((f.name + '.len'))}); // ${f.max_size}
-    if (ret != ${f.array_max_size_bit_len})
-    {
-        goto ${type_name}_error_exit;
-    }
-    offset += ${f.array_max_size_bit_len};
-                %endif
 
     //  - Get Array
     if (dyn_arr_buf)
@@ -276,18 +226,18 @@ int32_t ${type_name}_decode_internal(
     {
                     %if isinstance(f.data_type.element_type, CompoundType)
         offset += ${f.c_type}_decode_internal(transfer,
-                                                0,
-                                                (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
-                                                dyn_arr_buf,
-                                                offset);
+                                              0,
+                                              (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
+                                              dyn_arr_buf,
+                                              offset);
                     %else
         if (dyn_arr_buf)
         {
             ret = canardDecodePrimitive(transfer,
-                                     (uint32_t)offset,
-                                     ${f.bitlen},
-                                     ${f.signedness},
-                                     (void*)*dyn_arr_buf); // ${f.max_size}
+                                        (uint32_t)offset,
+                                        ${f.bitlen},
+                                        ${f.signedness},
+                                        (void*)*dyn_arr_buf); // ${f.max_size}
             if (ret != ${f.bitlen})
             {
                 goto ${type_name}_error_exit;

--- a/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/data_type_template.tmpl
@@ -118,7 +118,7 @@ typedef struct
 @!storage_class!@uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf);
 @!storage_class!@int32_t ${type_name}_decode(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf);
 
-@!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset, uint8_t root_item);
+@!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset);
 @!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset);
  %else
 typedef struct
@@ -127,7 +127,7 @@ typedef struct
 } ${type_name};
 @!storage_class!@uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf);
 @!storage_class!@int32_t ${type_name}_decode(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf);
-@!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset, uint8_t root_item);
+@!storage_class!@uint32_t ${type_name}_encode_internal(${type_name}* source, void* msg_buf, uint32_t offset);
 @!storage_class!@int32_t ${type_name}_decode_internal(const CanardRxTransfer* transfer, uint16_t payload_len, ${type_name}* dest, uint8_t** dyn_arr_buf, int32_t offset);
 
  %endif


### PR DESCRIPTION
My attempt of removing TAO support #108 . I think I have done it correctly, but please verify that the decode and encode functionality of autogenerated code is correct. 
Example of uavcan/node/Record: [Record.1.0.txt](https://github.com/UAVCAN/libcanard/files/3035273/Record.1.0.txt)

