### PR TITLE
Fixing bugs in DSDL compiler

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -92,8 +92,15 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
     // Static array (${f.name})
     for (c = 0; c < ${f.array_size}; c++)
     {
-        canardEncodePrimitive(msg_buf, offset, ${f.bitlen}, (void*)(source->${f.name} + c)); // ${f.max_size}
+                %if isinstance(f.data_type.element_type, CompoundType)
+        offset = ${f.c_type}_encode_internal((void*)&source->${'%s' % ((f.name))}[c], msg_buf, offset);
+                %else
+        canardEncodePrimitive(msg_buf,
+                              offset,
+                              ${f.bitlen},
+                              (void*)(source->${'%s' % ((f.name))} + c));// ${f.max_size}
         offset += ${f.bitlen};
+                %endif
     }
             %endif
 
@@ -223,11 +230,16 @@ int32_t ${type_name}_decode_internal(
     for (c = 0; c < dest->${'%s' % ((f.name + '.len'))}; c++)
     {
                     %if isinstance(f.data_type.element_type, CompoundType)
-        offset += ${f.c_type}_decode_internal(transfer,
+        offset = ${f.c_type}_decode_internal(transfer,
                                               0,
                                               (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
                                               dyn_arr_buf,
                                               offset);
+        if (offset < 0)
+        {
+            ret = offset;
+            goto ${type_name}_error_exit;
+        }
                     %else
         if (dyn_arr_buf)
         {
@@ -250,12 +262,25 @@ int32_t ${type_name}_decode_internal(
     // Static array (${f.name})
     for (c = 0; c < ${f.array_size}; c++)
     {
+                    %if isinstance(f.data_type.element_type, CompoundType)
+        offset = ${f.c_type}_decode_internal(transfer,
+                                              0,
+                                              (void*)&dest->${'%s' % ((f.name))}[c],
+                                              dyn_arr_buf,
+                                              offset);
+        if (offset < 0)
+        {
+            ret = offset;
+            goto ${type_name}_error_exit;
+        }
+                    %else
         ret = canardDecodePrimitive(transfer, (uint32_t)offset, ${f.bitlen}, ${f.signedness}, (void*)(dest->${f.name} + c));
         if (ret != ${f.bitlen})
         {
             goto ${type_name}_error_exit;
         }
         offset += ${f.bitlen};
+                    %endif
     }
             %endif
         %elif isinstance(f.data_type, VoidType)


### PR DESCRIPTION
Found a couple of bugs in the template used by the DSDL compiler:
* All elements in static arrays were decoded as primitive types even if they were compound types.
* Signedness of return code was not checked before incrementing offset value for decode_internal of compound types.
* ~~Offset were not incremented for compound types during encoding.~~

**Edit:** Found out I had made a mistake and the last point actually were correct. Reverted those changes now, so only the first two remains.
