### PR TITLE
Fix DSDL Compiler Dynamic Array Encoding/Decoding Issues

### DIFF
--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -34,7 +34,7 @@
   * @param msg_buf: pointer to msg storage
   * @param offset: bit offset to msg storage
   * @param root_item: for detecting if TAO should be used
-  * @retval returns offset
+  * @retval returns new offset
   */
 uint32_t ${type_name}_encode_internal(${type_name}* source,
   void* msg_buf,
@@ -96,7 +96,7 @@ uint32_t ${type_name}_encode_internal(${type_name}* source,
     for (c = 0; c < source->${'%s' % ((f.name + '.len'))}; c++)
     {
                 %if f.cpp_type_category == t.CATEGORY_COMPOUND:
-        offset += ${f.cpp_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
+        offset = ${f.cpp_type}_encode_internal((void*)&source->${'%s' % ((f.name + '.data'))}[c], msg_buf, offset, 0);
                 %else
         canardEncodeScalar(msg_buf,
                            offset,

--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -279,7 +279,7 @@ int32_t ${type_name}_decode_internal(
     for (c = 0; c < dest->${'%s' % ((f.name + '.len'))}; c++)
     {
                     %if f.cpp_type_category == t.CATEGORY_COMPOUND:
-        offset += ${f.cpp_type}_decode_internal(transfer,
+        offset = ${f.cpp_type}_decode_internal(transfer,
                                                 0,
                                                 (void*)&dest->${'%s' % ((f.name + '.data'))}[c],
                                                 dyn_arr_buf,

--- a/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
+++ b/dsdl_compiler/libcanard_dsdl_compiler/code_type_template.tmpl
@@ -180,7 +180,7 @@ uint32_t ${type_name}_encode(${type_name}* source, void* msg_buf)
   *                     ${type_name} dyn memory will point to dyn_arr_buf memory.
   *                     NULL will ignore dynamic arrays decoding.
   * @param offset: Call with 0, bit offset to msg storage
-  * @retval offset or ERROR value if < 0
+  * @retval new offset or ERROR value if < 0
   */
 int32_t ${type_name}_decode_internal(
   const CanardRxTransfer* transfer,


### PR DESCRIPTION
In using dynamic arrays in my project, I came across a major issue where the first two elements in an array would be decoded correctly, but any element after that was mangled and useless.

After a few hours of debugging, (and some major help from some friends) we traced it back to the DSDLC-generated decode_internal functions.

Essentially, we found that the loop that decodes each element in the array adds the value returned by the decode_internal function of the internal data structure, which returns the cumulative offset expands way too fast. The offset value is essentially added to itself *and* the incremented value each time, which means that new elements are essentially placed in arbitrary memory locations.

The encode fix hasn't been entirely tested, but looking at the code it follows with the same logical error as the decoding issue, and changing the += to = fixed the issue entirely in decoding.

