### PR TITLE
Modification to TID handling and new tests to cover TID and timeout

### DIFF
--- a/canard.c
+++ b/canard.c
@@ -318,7 +318,7 @@ int16_t canardHandleRxFrame(CanardInstance* ins, const CanardCANFrame* frame, ui
     const bool tid_timed_out = (timestamp_usec - rx_state->timestamp_usec) > TRANSFER_TIMEOUT_USEC;
     const bool first_frame = IS_START_OF_TRANSFER(tail_byte);
     const bool not_previous_tid =
-        computeTransferIDForwardDistance((uint8_t) rx_state->transfer_id, TRANSFER_ID_FROM_TAIL_BYTE(tail_byte)) >= 1;
+        computeTransferIDForwardDistance(TRANSFER_ID_FROM_TAIL_BYTE(tail_byte), (uint8_t) rx_state->transfer_id) > 1;
     const bool need_restart =
             (not_initialized) ||
             (tid_timed_out) ||

--- a/canard.h
+++ b/canard.h
@@ -79,6 +79,7 @@ extern "C" {
 #define CANARD_ERROR_RX_UNEXPECTED_TID                 15
 #define CANARD_ERROR_RX_SHORT_FRAME                    16
 #define CANARD_ERROR_RX_BAD_CRC                        17
+#define CANARD_ERROR_RX_DUPLICATE_TID                  18
 
 /// The size of a memory block in bytes.
 #define CANARD_MEM_BLOCK_SIZE                       32U


### PR DESCRIPTION
We found an issue where sometimes receiving packets would fail following a packet timing out. This commit makes the TID handling more consistent - the rx state TID is no longer incremented when a packet is succesfully decoded/fails - previously it would be incremented to the "next expected" TID.

Tests have been added to cover various TID/timeout scenarios.