### PR TITLE
[WIP] Implemented support for CAN-FD with dynamically sized allocator blocks.

### DIFF
--- a/canard_internals.h
+++ b/canard_internals.h
@@ -43,7 +43,6 @@ extern "C" {
 # define CANARD_INTERNAL static
 #endif
 
-
 CANARD_INTERNAL CanardRxState* traverseRxStates(CanardInstance* ins,
                                                 uint32_t transfer_descriptor);
 
@@ -68,12 +67,12 @@ CANARD_INTERNAL CanardTransferType extractTransferType(uint32_t id);
 CANARD_INTERNAL uint16_t extractDataType(uint32_t id);
 
 CANARD_INTERNAL void pushTxQueue(CanardInstance* ins,
-                                 CanardTxQueueItem* item);
+                                 CanardTxItem* item);
 
 CANARD_INTERNAL bool isPriorityHigher(uint32_t id,
                                       uint32_t rhs);
 
-CANARD_INTERNAL CanardTxQueueItem* createTxItem(CanardPoolAllocator* allocator);
+CANARD_INTERNAL CanardTxItem* createTxItem(CanardPoolAllocator* allocator);
 
 CANARD_INTERNAL void prepareForNextTransfer(CanardRxState* state);
 
@@ -103,7 +102,8 @@ CANARD_INTERNAL void copyBitArray(const uint8_t* src,
  * Moves specified bits from the scattered transfer storage to a specified contiguous buffer.
  * Returns the number of bits copied, or negated error code.
  */
-CANARD_INTERNAL int16_t descatterTransferPayload(const CanardRxTransfer* transfer,
+CANARD_INTERNAL int16_t descatterTransferPayload(const CanardInstance* ins,
+                                                 const CanardRxTransfer* transfer,
                                                  uint32_t bit_offset,
                                                  uint8_t bit_length,
                                                  void* output);
@@ -130,8 +130,9 @@ CANARD_INTERNAL uint16_t crcAdd(uint16_t crc_val,
  * @param [in] buf_len The number of blocks in buf.
  */
 CANARD_INTERNAL void initPoolAllocator(CanardPoolAllocator* allocator,
-                                       CanardPoolAllocatorBlock* buf,
-                                       uint16_t buf_len);
+                                       void* buf,
+                                       size_t buf_len,
+                                       size_t block_size);
 
 /**
  * Allocates a block from the given pool allocator.

--- a/drivers/socketcan/socketcan.c
+++ b/drivers/socketcan/socketcan.c
@@ -93,7 +93,7 @@ int16_t socketcanClose(SocketCANInstance* ins)
     return (int16_t)((close_result == 0) ? 0 : getErrorCode());
 }
 
-int16_t socketcanTransmit(SocketCANInstance* ins, const CanardCANFrame* frame, int32_t timeout_msec)
+int16_t socketcanTransmit(SocketCANInstance* ins, const CanardTxItem* frame, int32_t timeout_msec)
 {
     struct pollfd fds;
     memset(&fds, 0, sizeof(fds));

--- a/drivers/socketcan/socketcan.h
+++ b/drivers/socketcan/socketcan.h
@@ -37,7 +37,7 @@ int16_t socketcanClose(SocketCANInstance* ins);
  * Use negative timeout to block infinitely.
  * Returns 1 on successful transmission, 0 on timeout, negative on error.
  */
-int16_t socketcanTransmit(SocketCANInstance* ins, const CanardCANFrame* frame, int32_t timeout_msec);
+int16_t socketcanTransmit(SocketCANInstance* ins, const CanardTxItem* frame, int32_t timeout_msec);
 
 /**
  * Receives a CanardCANFrame from the CAN socket.

--- a/tests/test_init.cpp
+++ b/tests/test_init.cpp
@@ -45,6 +45,7 @@ TEST_CASE("Init, UserReference")
 
     ::CanardInstance ins;
     canardInit(&ins,
+               CanardTransportProtocolCan2B,
                memory_arena,
                sizeof(memory_arena),
                &onTransferReceptionMock,

--- a/tests/test_rxerr.cpp
+++ b/tests/test_rxerr.cpp
@@ -99,7 +99,7 @@ TEST_CASE("canardHandleRxFrame incompatible packet handling, Correctness")
     //Setup frame data to be single frame transfer
     frame.data[0] = CONSTRUCT_TAIL_BYTE(1, 1, 1, 0);
 
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     g_should_accept = true;
 
@@ -145,7 +145,7 @@ TEST_CASE("canardHandleRxFrame wrong address handling, Correctness")
     frame.data[0] = CONSTRUCT_TAIL_BYTE(1, 1, 1, 0);
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
     g_should_accept = true;
@@ -175,7 +175,7 @@ TEST_CASE("canardHandleRxFrame shouldAccept handling, Correctness")
     frame.data[0] = CONSTRUCT_TAIL_BYTE(1, 1, 1, 0);
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
 
@@ -204,7 +204,7 @@ TEST_CASE("canardHandleRxFrame no state handling, Correctness")
     g_should_accept = true;
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
 
@@ -270,7 +270,7 @@ TEST_CASE("canardHandleRxFrame missed start handling, Correctness")
     g_should_accept = true;
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
 
@@ -329,7 +329,7 @@ TEST_CASE("canardHandleRxFrame short frame handling, Correctness")
     g_should_accept = true;
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, canard_memory_pool, sizeof(canard_memory_pool),
+    canardInit(&canard, CanardTransportProtocolCan2B, canard_memory_pool, sizeof(canard_memory_pool),
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
 
@@ -358,7 +358,7 @@ TEST_CASE("canardHandleRxFrame OOM handling, Correctness")
     g_should_accept = true;
 
     //Open canard to accept all transfers with a node ID of 20
-    canardInit(&canard, &dummy_buf, 0,
+    canardInit(&canard, CanardTransportProtocolCan2B, &dummy_buf, 0,
                onTransferReceived, shouldAcceptTransfer, &canard);
     canardSetLocalNodeID(&canard, 20);
 

--- a/tests/test_scalar_encoding.cpp
+++ b/tests/test_scalar_encoding.cpp
@@ -39,11 +39,11 @@ TEST_CASE("BigEndian, Check")
 
 
 template <typename T>
-static inline T read(CanardRxTransfer* transfer, uint32_t bit_offset, uint8_t bit_length)
+static inline T read(CanardInstance* ins, CanardRxTransfer* transfer, uint32_t bit_offset, uint8_t bit_length)
 {
     auto value = T();
 
-    const int res = canardDecodePrimitive(transfer, uint16_t(bit_offset), bit_length, std::is_signed<T>::value, &value);
+    const int res = canardDecodePrimitive(ins, transfer, uint16_t(bit_offset), bit_length, std::is_signed<T>::value, &value);
     if (res != bit_length)
     {
         throw std::runtime_error("Unexpected return value; expected " +
@@ -56,6 +56,10 @@ static inline T read(CanardRxTransfer* transfer, uint32_t bit_offset, uint8_t bi
 
 TEST_CASE("ScalarDecode, SingleFrame")
 {
+    CanardInstance mock_ins;
+    mock_ins.transport = CanardTransportProtocolCan2B;
+    mock_ins.allocator.block_size = CANARD_MEM_BLOCK_SIZE_CAN_2B;
+
     auto transfer = CanardRxTransfer();
 
     static const uint8_t buf[7] =
@@ -72,14 +76,14 @@ TEST_CASE("ScalarDecode, SingleFrame")
     transfer.payload_head = &buf[0];
     transfer.payload_len = sizeof(buf);
 
-    REQUIRE(0b10100101 == read<uint8_t>(&transfer, 0, 8));
-    REQUIRE(0b01011100 == read<uint8_t>(&transfer, 4, 8));
-    REQUIRE(0b00000101 == read<uint8_t>(&transfer, 4, 4));
+    REQUIRE(0b10100101 == read<uint8_t>(&mock_ins, &transfer, 0, 8));
+    REQUIRE(0b01011100 == read<uint8_t>(&mock_ins, &transfer, 4, 8));
+    REQUIRE(0b00000101 == read<uint8_t>(&mock_ins, &transfer, 4, 4));
 
-    REQUIRE(read<bool>(&transfer, 9, 1));
-    REQUIRE_FALSE(read<bool>(&transfer, 10, 1));
+    REQUIRE(read<bool>(&mock_ins, &transfer, 9, 1));
+    REQUIRE_FALSE(read<bool>(&mock_ins, &transfer, 10, 1));
 
-    REQUIRE(0b11101000101010100101010101111110 == read<uint32_t>(&transfer, 24, 32));
+    REQUIRE(0b11101000101010100101010101111110 == read<uint32_t>(&mock_ins, &transfer, 24, 32));
 
     /*
      * Raw bit stream with offset 21:
@@ -89,50 +93,70 @@ TEST_CASE("ScalarDecode, SingleFrame")
      * Which is little endian representation of:
      *   0b01011101101101011100101011101111
      */
-    REQUIRE(0b01011101101101011100101011101111 == read<uint32_t>(&transfer, 21, 32));
+    REQUIRE(0b01011101101101011100101011101111 == read<uint32_t>(&mock_ins, &transfer, 21, 32));
 
     // Should fail
-    REQUIRE_THROWS_AS(read<uint32_t>(&transfer, 25, 32), std::runtime_error);
+    REQUIRE_THROWS_AS(read<uint32_t>(&mock_ins, &transfer, 25, 32), std::runtime_error);
 
     // Inexact size
-    REQUIRE(0b010111101101011100101011101111 == read<uint32_t>(&transfer, 21, 30));
+    REQUIRE(0b010111101101011100101011101111 == read<uint32_t>(&mock_ins, &transfer, 21, 30));
 
     // Negatives; reference values taken from libuavcan test suite or computed manually
-    REQUIRE(-1 == read<int8_t>(&transfer, 16, 3));  // 0b111
-    REQUIRE(-4 == read<int8_t>(&transfer, 2, 3));   // 0b100
+    REQUIRE(-1 == read<int8_t>(&mock_ins, &transfer, 16, 3));  // 0b111
+    REQUIRE(-4 == read<int8_t>(&mock_ins, &transfer, 2, 3));   // 0b100
 
-    REQUIRE(-91    == read<int8_t>(&transfer, 0, 8));       //         0b10100101
-    REQUIRE(-15451 == read<int16_t>(&transfer, 0, 16));     // 0b1100001110100101
-    REQUIRE(-7771  == read<int16_t>(&transfer, 0, 15));     //  0b100001110100101
+    REQUIRE(-91    == read<int8_t>(&mock_ins, &transfer, 0, 8));       //         0b10100101
+    REQUIRE(-15451 == read<int16_t>(&mock_ins, &transfer, 0, 16));     // 0b1100001110100101
+    REQUIRE(-7771  == read<int16_t>(&mock_ins, &transfer, 0, 15));     //  0b100001110100101
 }
 
 
 TEST_CASE("ScalarDecode, MultiFrame")
 {
+    uint8_t node_id = 42;
+    std::uint8_t memory_arena[4096];
+    ::CanardInstance ins;
+
+    auto onTransferReception = [](CanardInstance*, CanardRxTransfer*) {
+        // do nothing
+    };
+    auto acceptAllTransfers = [](const CanardInstance*,
+                                 uint16_t,
+                                 CanardTransferType,
+                                 uint8_t)
+    {
+        return true;
+    };
+
     /*
-     * Configuring allocator
+     * Configuring instance (and implicitly allocator)
      */
-    CanardPoolAllocatorBlock allocator_blocks[2];
-    CanardPoolAllocator allocator;
-    initPoolAllocator(&allocator, &allocator_blocks[0], 2);
+    canardInit(&ins,
+                CanardTransportProtocolCan2B,
+                memory_arena,
+                sizeof(memory_arena),
+                onTransferReception,
+                acceptAllTransfers,
+                reinterpret_cast<void*>(12345));
+
 
     /*
      * Configuring the transfer object
      */
     auto transfer = CanardRxTransfer();
 
-    uint8_t head[CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE];
+    uint8_t head[(CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE)];
     for (auto& x : head)
     {
         x = 0b10100101;
     }
-    static_assert(CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE == 6, "Assumption is not met, are we on a 32-bit x86 machine?");
+    static_assert((CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) == 6, "Assumption is not met, are we on a 32-bit x86 machine?");
 
-    auto middle_a = createBufferBlock(&allocator);
-    auto middle_b = createBufferBlock(&allocator);
+    auto middle_a = createBufferBlock(&ins.allocator);
+    auto middle_b = createBufferBlock(&ins.allocator);
 
-    std::fill_n(&middle_a->data[0], CANARD_BUFFER_BLOCK_DATA_SIZE, 0b01011010);
-    std::fill_n(&middle_b->data[0], CANARD_BUFFER_BLOCK_DATA_SIZE, 0b11001100);
+    std::fill_n(&middle_a->data[0], (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_BUFFER_BLOCK_HEADER_SIZE), 0b01011010);
+    std::fill_n(&middle_b->data[0], (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_BUFFER_BLOCK_HEADER_SIZE), 0b11001100);
 
     middle_a->next = middle_b;
     middle_b->next = nullptr;
@@ -150,41 +174,42 @@ TEST_CASE("ScalarDecode, MultiFrame")
     transfer.payload_tail   = &tail[0];
 
     transfer.payload_len =
-        uint16_t(CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE + CANARD_BUFFER_BLOCK_DATA_SIZE * 2 + sizeof(tail));
+        uint16_t((CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) + (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_BUFFER_BLOCK_HEADER_SIZE) * 2 + sizeof(tail));
 
     std::cout << "Payload size: " << transfer.payload_len << std::endl;
 
     /*
      * Testing
      */
-    REQUIRE(0b10100101 == read<uint8_t>(&transfer, 0, 8));
-    REQUIRE(0b01011010 == read<uint8_t>(&transfer, 4, 8));
-    REQUIRE(0b00000101 == read<uint8_t>(&transfer, 4, 4));
+    REQUIRE(0b10100101 == read<uint8_t>(&ins, &transfer, 0, 8));
+    REQUIRE(0b01011010 == read<uint8_t>(&ins, &transfer, 4, 8));
+    REQUIRE(0b00000101 == read<uint8_t>(&ins, &transfer, 4, 4));
 
-    REQUIRE_FALSE(read<bool>(&transfer, CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE * 8, 1));
-    REQUIRE(read<bool>(&transfer, CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE * 8 + 1, 1));
+    REQUIRE(0b01011010 == read<uint8_t>(&ins, &transfer, (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) * 8, 8));
+
+    REQUIRE_FALSE(read<bool>(&ins, &transfer, (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) * 8, 1));
+    REQUIRE(read<bool>(&ins, &transfer, (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) * 8 + 1, 1));
 
     // 64 from beginning, 48 bits from head, 16 bits from the middle
-    REQUIRE(0b0101101001011010101001011010010110100101101001011010010110100101ULL == read<uint64_t>(&transfer, 0, 64));
+    REQUIRE(0b0101101001011010101001011010010110100101101001011010010110100101ULL == read<uint64_t>(&ins, &transfer, 0, 64));
 
     // 64 from two middle blocks, 32 from the first, 32 from the second
     REQUIRE(0b1100110011001100110011001100110001011010010110100101101001011010ULL ==
-            read<uint64_t>(&transfer,
-                           CANARD_MULTIFRAME_RX_PAYLOAD_HEAD_SIZE * 8 + CANARD_BUFFER_BLOCK_DATA_SIZE * 8 - 32, 64));
-
+            read<uint64_t>(&ins, &transfer,
+                           (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_MULTIFRAME_RX_TRANSFER_HEADER_SIZE) * 8 + (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_BUFFER_BLOCK_HEADER_SIZE) * 8 - 32, 64));
     // Last 64
     REQUIRE(0b0100010000110011001000100001000111001100110011001100110011001100ULL ==
-            read<uint64_t>(&transfer, transfer.payload_len * 8U - 64U, 64));
+            read<uint64_t>(&ins, &transfer, transfer.payload_len * 8U - 64U, 64));
 
     /*
      * Testing without the middle
      */
     transfer.payload_middle = nullptr;
-    transfer.payload_len = uint16_t(transfer.payload_len - CANARD_BUFFER_BLOCK_DATA_SIZE * 2U);
+    transfer.payload_len = uint16_t(transfer.payload_len - (CANARD_MEM_BLOCK_SIZE_CAN_2B - CANARD_BUFFER_BLOCK_HEADER_SIZE) * 2U);
 
     // Last 64
     REQUIRE(0b0100010000110011001000100001000110100101101001011010010110100101ULL ==
-            read<uint64_t>(&transfer, transfer.payload_len * 8U - 64U, 64));
+            read<uint64_t>(&ins, &transfer, transfer.payload_len * 8U - 64U, 64));
 }
 
 


### PR DESCRIPTION
Not all done, please leave initial feedback. Look at todo to see what you can refrain from commenting.

### Design:
The design is based around adding a notion of protocol to the interface that will only affect the maximum data size of transmitted frames (output from libcanard). 

The received frames (input to libcanard) has been changed to accept an array of variable size to allow receiving from all kinds of interfaces in all kinds of modes (to support bootloaders etc, ref prior discussion).

Convinient types (with data size corresponding to CAN 2B and CAN FD) for reception of CAN frames is provided in canard.h. This is not strictly necessary but avoids the hassle of making sure your type is compatible with the `CanardCANframe` type.

### Constraints:
#### Transmitted frames != received frames
Due to C being quite awfull I'm not allowed to create the following type
```c
struct CanardTxItem
{
    CanardTxItem* next;
    CanardCANFrame * frame;
};
```
This forces me to unroll the fields of `CanardCANFrame` into `CanardTxItem` like the following
```C
struct CanardTxItem
{
    CanardTxItem* next;
    uint32_t id;
    uint8_t data_len;
    uint8_t data[];
};
```
After reading the C specification on type compatibility i see no way to safely return a `CanardCANFrame*` from this type. Which unfortunately means that the whole `CanardTxItem` must be returned or data must be copied. I don't think this is great, but not terrible either (this being C). We are only returning const pointers of this block so messing up the `next` field should be considered misuse.


### Todos:

 - [ ] Add FD equivalent tests to what exists for 2B
 - [ ] Write tests for functionality that is touched and previously did not have tests
 - [ ] Update the .md files
 - [ ] Try to massage the FD block size down to 80 bytes
 - [ ] Attempt to write assert on all properties required to be compatible types for can frame types.

