### PR TITLE
Fix some bugs in readme doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ CanardRxSubscription heartbeat_subscription;
                          CanardTransferKindMessage,
                          32085,  // The fixed Subject-ID of the Heartbeat message type (see DSDL definition).
                          7,      // The maximum payload size (max DSDL object size) from the DSDL definition.
+                         CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
                          &heartbeat_subscription);
 
 CanardRxSubscription my_service_subscription;
@@ -147,6 +148,7 @@ CanardRxSubscription my_service_subscription;
                          CanardTransferKindResponse,
                          123,                         // The Service-ID to subscribe to.
                          1024,                        // The maximum payload size (max DSDL object size).
+                         CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC,
                          &my_service_subscription);
 ```
 

--- a/libcanard/canard.h
+++ b/libcanard/canard.h
@@ -559,6 +559,7 @@ int8_t canardRxAccept(CanardInstance* const    ins,
 /// called the Implicit Truncation Rule (ITR) and it is intended to facilitate extensibility of data types while
 /// preserving backward compatibility. The transfer CRC is validated regardless of whether its payload is truncated.
 ///
+/// The default transfer-ID timeout value is defined as CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC; use it if not sure.
 /// The redundant transport fail-over timeout (if redundant transports are used) is the same as the transfer-ID timeout.
 /// It may be reduced in a future release of the library, but it will not affect the backward compatibility.
 ///


### PR DESCRIPTION
```
int8_t canardRxSubscribe(CanardInstance* const       ins,
                         const CanardTransferKind    transfer_kind,
                         const CanardPortID          port_id,
                         const size_t                payload_size_max,
                         const CanardMicrosecond     transfer_id_timeout_usec,
                         CanardRxSubscription* const out_subscription)
```
    Maybe we need `transfer_id_timeout_usec` this param for this function.