### PR TITLE
Add canardRxAccept2(), fix #163

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,12 @@ matrix:
         - CC=gcc-10
         - CXX=g++-10
       script:
-        - sudo apt-get update
-        - sudo apt-get -y autoremove
+        - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
-        - sudo apt-get -y upgrade
-        - sudo apt-get -y autoremove
-        - sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-        - sudo apt-get update
+        - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
+        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
         - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+
         # ANALYSIS
         # Using the build wrapper from Sonar and collecting the code coverage.
         # Define NDEBUG=1 to avoid assertion checks being reported as uncovered statements.
@@ -53,16 +51,13 @@ matrix:
 
     # -------------------- Clang --------------------
     - language: cpp
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:  # Install a newer GCC because https://stackoverflow.com/a/51512150/1007777.
-            - g++-10
-            - g++-10-multilib
-            - gcc-10-multilib
-            - linux-libc-dev:i386
       script:
+        - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
+        - sudo apt-get -yf install  # fix missing
+        - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
+        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
+        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+
         # Set up the toolchain.
         - wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 11
         - sudo apt install clang-tidy-11 clang-format-11

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,12 +64,12 @@ matrix:
             - linux-libc-dev:i386
       script:
         # Set up the toolchain.
-        - wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 10
-        - sudo apt install clang-tidy-10 clang-format-10
-        - clang++-10 -E -x c++ - -v < /dev/null    # Print the Clang configuration for troubleshooting purposes.
+        - wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 11
+        - sudo apt install clang-tidy-11 clang-format-11
+        - clang++-11 -E -x c++ - -v < /dev/null    # Print the Clang configuration for troubleshooting purposes.
 
         # DEBUG + format check
-        - cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 tests -DCMAKE_BUILD_TYPE=Debug
+        - cmake -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 tests -DCMAKE_BUILD_TYPE=Debug
         - make VERBOSE=1 && make test
         - make format VERBOSE=1
         - 'modified="$(git status --porcelain --untracked-files=no)"'
@@ -78,12 +78,12 @@ matrix:
         - make clean
 
         # RELEASE (skip static analysis because it is done in the DEBUG configuration)
-        - cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 tests -DCMAKE_BUILD_TYPE=Release -DNO_STATIC_ANALYSIS=1
+        - cmake -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 tests -DCMAKE_BUILD_TYPE=Release -DNO_STATIC_ANALYSIS=1
         - make VERBOSE=1 && make test
         - make clean
 
         # MINSIZEREL (skip static analysis because it is done in the DEBUG configuration)
-        - cmake -DCMAKE_C_COMPILER=clang-10 -DCMAKE_CXX_COMPILER=clang++-10 tests -DCMAKE_BUILD_TYPE=MinSizeRel -DNO_STATIC_ANALYSIS=1
+        - cmake -DCMAKE_C_COMPILER=clang-11 -DCMAKE_CXX_COMPILER=clang++-11 tests -DCMAKE_BUILD_TYPE=MinSizeRel -DNO_STATIC_ANALYSIS=1
         - make VERBOSE=1 && make test
         - make clean
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,18 @@ matrix:
           organization: uavcan
           token:
             secure: "LbaAOcguJspiraxAb9RNkwtGvWDh1aMTEPdz2MCbeICxIIiJ6LRoabD58rLvPsrNSWsR3AAep9Q551dDzT8c04UX+C67N3CZ/oof4DwBT+XQCSfB8FMj2QpbglJqwFPclYUorROjH31VwGcgIq3kfQq3Cw8G+nsL8vRaaJXsJb/KPp6MU698NGzHJIgRyn29VW76dW0NSxOv4ub3e6aKOnwfI+h1Ctx4p3hCdzd402PaZspv1VgEmirf5sVUJvE67PVIzlwov+CF+2PlrIpGUWI98Gl6HqYHv3hkvSP+4iLvCMD99Zmee4yLnCFY3xcJuZ8zKCRBBoquuUxdzK0f/4l9TZXePDXDMhaj3cXLlaAPWDw+emqTcm+hzP1mt/DaIqopAf54bQojVWELbL6QcjBNkphSvWBeIoyKWuUWU2LWJcJNPXFNUug//D99uXNurkzAIWR+lcsx6zO+cr4EN00N92W6hPt7mhKCF0prs7SvMleEi9mAbxvd4lOHFT56RvcB5ny6IapX9/q1+xm5iSoAzLhbvU1aUCnX74S/yFFejvClxxhW+P0bXYNtZ9RRfl8BdSgENTgA9RSnqdtIJGA4cU3OxIHDyJIC2cgmsE38u7QaMO49r1liJFH+xmDPa6bkGGHiPoHaPu9+g+wYFttK9FNt5ozyHY+VpjwTrY4="
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-10
-            - g++-10-multilib
-            - gcc-10-multilib
-            - linux-libc-dev:i386
       env:
         - CC=gcc-10
         - CXX=g++-10
       script:
+        - sudo apt-get update
+        - sudo apt-get -y autoremove
+        - sudo apt-get -yf install  # fix missing
+        - sudo apt-get -y upgrade
+        - sudo apt-get -y autoremove
+        - sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+        - sudo apt-get update
+        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
         # ANALYSIS
         # Using the build wrapper from Sonar and collecting the code coverage.
         # Define NDEBUG=1 to avoid assertion checks being reported as uncovered statements.
@@ -56,7 +56,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:  # Install a newer GCC because https://stackoverflow.com/a/51512150/1007777.
             - g++-10
             - g++-10-multilib

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ matrix:
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
-        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
-        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+        - sudo apt-get -yfq --allow-downgrades install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
 
         # ANALYSIS
         # Using the build wrapper from Sonar and collecting the code coverage.
@@ -55,8 +54,7 @@ matrix:
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
-        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
-        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+        - sudo apt-get -yfq --allow-downgrades install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
 
         # Set up the toolchain.
         - wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ matrix:
     # -------------------- Clang --------------------
     - language: cpp
       script:
+        - echo 'APT::Get::AllowUnauthenticated "true";' | sudo tee /etc/apt/apt.conf.d/99insecure
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ matrix:
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
-        - sudo apt-get -yfq --allow-downgrades install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
+        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
 
         # ANALYSIS
         # Using the build wrapper from Sonar and collecting the code coverage.
@@ -54,7 +55,8 @@ matrix:
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
         - sudo apt-get -yf install  # fix missing
         - sudo apt-get update ; sudo apt-get -y upgrade ; sudo apt-get -y autoremove
-        - sudo apt-get -yfq --allow-downgrades install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
+        - sudo apt-get -yf --allow-downgrades install libc6=2.31-0ubuntu9.2  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1926918
+        - sudo apt-get -yfq install g++-10 g++-10-multilib gcc-10-multilib linux-libc-dev:i386
 
         # Set up the toolchain.
         - wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 11

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,8 @@ to prevent non-compliant code from being accepted into upstream.
 
 The following tools are required to conduct library development locally:
 
-- GCC v9 or newer.
-- Clang and Clang-Tools v9 or newer.
+- GCC v10 or newer.
+- Clang and Clang-Tools v11 or newer.
 - CMake v3.12 or newer.
 - An AMD64 machine.
 

--- a/libcanard/.clang-tidy
+++ b/libcanard/.clang-tidy
@@ -16,6 +16,9 @@ Checks: >-
   -google-readability-todo,
   -readability-avoid-const-params-in-decls,
   -llvm-header-guard,
+CheckOptions:
+  - key:   readability-function-cognitive-complexity.Threshold
+    value: '99'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -958,10 +958,11 @@ void canardTxPop(CanardInstance* const ins)
     }
 }
 
-int8_t canardRxAccept(CanardInstance* const    ins,
-                      const CanardFrame* const frame,
-                      const uint8_t            redundant_transport_index,
-                      CanardTransfer* const    out_transfer)
+int8_t canardRxAccept2(CanardInstance* const        ins,
+                       const CanardFrame* const     frame,
+                       const uint8_t                redundant_transport_index,
+                       CanardTransfer* const        out_transfer,
+                       CanardRxSubscription** const out_subscription)
 {
     int8_t out = -CANARD_ERROR_INVALID_ARGUMENT;
     if ((ins != NULL) && (out_transfer != NULL) && (frame != NULL) && (frame->extended_can_id <= CAN_EXT_ID_MASK) &&
@@ -980,6 +981,11 @@ int8_t canardRxAccept(CanardInstance* const    ins,
                 while ((sub != NULL) && (sub->_port_id != model.port_id))
                 {
                     sub = sub->_next;
+                }
+
+                if (out_subscription != NULL)
+                {
+                    *out_subscription = sub;  // Expose selected instance to the caller.
                 }
 
                 if (sub != NULL)
@@ -1004,6 +1010,14 @@ int8_t canardRxAccept(CanardInstance* const    ins,
     }
     CANARD_ASSERT(out <= 1);
     return out;
+}
+
+int8_t canardRxAccept(CanardInstance* const    ins,
+                      const CanardFrame* const frame,
+                      const uint8_t            redundant_transport_index,
+                      CanardTransfer* const    out_transfer)
+{
+    return canardRxAccept2(ins, frame, redundant_transport_index, out_transfer, NULL);
 }
 
 int8_t canardRxSubscribe(CanardInstance* const       ins,

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -16,9 +16,7 @@
 #endif
 
 /// This macro is needed only for testing and for library development. Do not redefine this in production.
-#if defined(CANARD_CONFIG_EXPOSE_PRIVATE) && CANARD_CONFIG_EXPOSE_PRIVATE
-#    define CANARD_PRIVATE
-#else  // Consider defining an extra compilation option that turns this into "static inline"?
+#ifndef CANARD_PRIVATE
 #    define CANARD_PRIVATE static
 #endif
 
@@ -62,7 +60,6 @@ typedef uint16_t TransferCRC;
 #define CRC_RESIDUE 0x0000U
 #define CRC_SIZE_BYTES 2U
 
-CANARD_PRIVATE TransferCRC crcAddByte(const TransferCRC crc, const uint8_t byte);
 CANARD_PRIVATE TransferCRC crcAddByte(const TransferCRC crc, const uint8_t byte)
 {
     static const TransferCRC Top  = 0x8000U;
@@ -81,7 +78,6 @@ CANARD_PRIVATE TransferCRC crcAddByte(const TransferCRC crc, const uint8_t byte)
     return out;
 }
 
-CANARD_PRIVATE TransferCRC crcAdd(const TransferCRC crc, const size_t size, const void* const data);
 CANARD_PRIVATE TransferCRC crcAdd(const TransferCRC crc, const size_t size, const void* const data)
 {
     CANARD_ASSERT((data != NULL) || (size == 0U));
@@ -114,7 +110,6 @@ typedef struct CanardInternalTxQueueItem
     uint8_t payload_buffer[];  // NOSONAR
 } CanardInternalTxQueueItem;
 
-CANARD_PRIVATE uint32_t txMakeMessageSessionSpecifier(const CanardPortID subject_id, const CanardNodeID src_node_id);
 CANARD_PRIVATE uint32_t txMakeMessageSessionSpecifier(const CanardPortID subject_id, const CanardNodeID src_node_id)
 {
     CANARD_ASSERT(src_node_id <= CANARD_NODE_ID_MAX);
@@ -123,10 +118,6 @@ CANARD_PRIVATE uint32_t txMakeMessageSessionSpecifier(const CanardPortID subject
     return src_node_id | (tmp << OFFSET_SUBJECT_ID);
 }
 
-CANARD_PRIVATE uint32_t txMakeServiceSessionSpecifier(const CanardPortID service_id,
-                                                      const bool         request_not_response,
-                                                      const CanardNodeID src_node_id,
-                                                      const CanardNodeID dst_node_id);
 CANARD_PRIVATE uint32_t txMakeServiceSessionSpecifier(const CanardPortID service_id,
                                                       const bool         request_not_response,
                                                       const CanardNodeID src_node_id,
@@ -141,7 +132,6 @@ CANARD_PRIVATE uint32_t txMakeServiceSessionSpecifier(const CanardPortID service
 }
 
 /// This is the transport MTU rounded up to next full DLC minus the tail byte.
-CANARD_PRIVATE size_t txGetPresentationLayerMTU(const CanardInstance* const ins);
 CANARD_PRIVATE size_t txGetPresentationLayerMTU(const CanardInstance* const ins)
 {
     const size_t max_index = (sizeof(CanardCANLengthToDLC) / sizeof(CanardCANLengthToDLC[0])) - 1U;
@@ -161,9 +151,6 @@ CANARD_PRIVATE size_t txGetPresentationLayerMTU(const CanardInstance* const ins)
     return mtu - 1U;
 }
 
-CANARD_PRIVATE int32_t txMakeCANID(const CanardTransfer* const tr,
-                                   const CanardNodeID          local_node_id,
-                                   const size_t                presentation_layer_mtu);
 CANARD_PRIVATE int32_t txMakeCANID(const CanardTransfer* const tr,
                                    const CanardNodeID          local_node_id,
                                    const size_t                presentation_layer_mtu)
@@ -233,10 +220,6 @@ CANARD_PRIVATE int32_t txMakeCANID(const CanardTransfer* const tr,
 CANARD_PRIVATE uint8_t txMakeTailByte(const bool             start_of_transfer,
                                       const bool             end_of_transfer,
                                       const bool             toggle,
-                                      const CanardTransferID transfer_id);
-CANARD_PRIVATE uint8_t txMakeTailByte(const bool             start_of_transfer,
-                                      const bool             end_of_transfer,
-                                      const bool             toggle,
                                       const CanardTransferID transfer_id)
 {
     CANARD_ASSERT(start_of_transfer ? (toggle == INITIAL_TOGGLE_STATE) : true);
@@ -245,7 +228,6 @@ CANARD_PRIVATE uint8_t txMakeTailByte(const bool             start_of_transfer,
 }
 
 /// Takes a frame payload size, returns a new size that is >=x and is rounded up to the nearest valid DLC.
-CANARD_PRIVATE size_t txRoundFramePayloadSizeUp(const size_t x);
 CANARD_PRIVATE size_t txRoundFramePayloadSizeUp(const size_t x)
 {
     CANARD_ASSERT(x < (sizeof(CanardCANLengthToDLC) / sizeof(CanardCANLengthToDLC[0])));
@@ -255,10 +237,6 @@ CANARD_PRIVATE size_t txRoundFramePayloadSizeUp(const size_t x)
     return CanardCANDLCToLength[y];
 }
 
-CANARD_PRIVATE CanardInternalTxQueueItem* txAllocateQueueItem(CanardInstance* const   ins,
-                                                              const uint32_t          id,
-                                                              const CanardMicrosecond deadline_usec,
-                                                              const size_t            payload_size);
 CANARD_PRIVATE CanardInternalTxQueueItem* txAllocateQueueItem(CanardInstance* const   ins,
                                                               const uint32_t          id,
                                                               const CanardMicrosecond deadline_usec,
@@ -281,7 +259,6 @@ CANARD_PRIVATE CanardInternalTxQueueItem* txAllocateQueueItem(CanardInstance* co
 
 /// Returns the element after which new elements with the specified CAN ID should be inserted.
 /// Returns NULL if the element shall be inserted in the beginning of the list (i.e., no prior elements).
-CANARD_PRIVATE CanardInternalTxQueueItem* txFindQueueSupremum(const CanardInstance* const ins, const uint32_t can_id);
 CANARD_PRIVATE CanardInternalTxQueueItem* txFindQueueSupremum(const CanardInstance* const ins, const uint32_t can_id)
 {
     CANARD_ASSERT(ins != NULL);
@@ -304,12 +281,6 @@ CANARD_PRIVATE CanardInternalTxQueueItem* txFindQueueSupremum(const CanardInstan
 }
 
 /// Returns the number of frames enqueued or error (i.e., =1 or <0).
-CANARD_PRIVATE int32_t txPushSingleFrame(CanardInstance* const   ins,
-                                         const CanardMicrosecond deadline_usec,
-                                         const uint32_t          can_id,
-                                         const CanardTransferID  transfer_id,
-                                         const size_t            payload_size,
-                                         const void* const       payload);
 CANARD_PRIVATE int32_t txPushSingleFrame(CanardInstance* const   ins,
                                          const CanardMicrosecond deadline_usec,
                                          const uint32_t          can_id,
@@ -364,13 +335,6 @@ CANARD_PRIVATE int32_t txPushSingleFrame(CanardInstance* const   ins,
 }
 
 /// Returns the number of frames enqueued or error.
-CANARD_PRIVATE int32_t txPushMultiFrame(CanardInstance* const   ins,
-                                        const size_t            presentation_layer_mtu,
-                                        const CanardMicrosecond deadline_usec,
-                                        const uint32_t          can_id,
-                                        const CanardTransferID  transfer_id,
-                                        const size_t            payload_size,
-                                        const void* const       payload);
 CANARD_PRIVATE int32_t txPushMultiFrame(CanardInstance* const   ins,
                                         const size_t            presentation_layer_mtu,
                                         const CanardMicrosecond deadline_usec,
@@ -541,7 +505,6 @@ typedef struct
 } RxFrameModel;
 
 /// Returns truth if the frame is valid and parsed successfully. False if the frame is not a valid UAVCAN/CAN frame.
-CANARD_PRIVATE bool rxTryParseFrame(const CanardFrame* const frame, RxFrameModel* const out);
 CANARD_PRIVATE bool rxTryParseFrame(const CanardFrame* const frame, RxFrameModel* const out)
 {
     CANARD_ASSERT(frame != NULL);
@@ -606,7 +569,6 @@ CANARD_PRIVATE bool rxTryParseFrame(const CanardFrame* const frame, RxFrameModel
     return valid;
 }
 
-CANARD_PRIVATE void rxInitTransferFromFrame(const RxFrameModel* const frame, CanardTransfer* const out_transfer);
 CANARD_PRIVATE void rxInitTransferFromFrame(const RxFrameModel* const frame, CanardTransfer* const out_transfer)
 {
     CANARD_ASSERT(frame != NULL);
@@ -622,7 +584,6 @@ CANARD_PRIVATE void rxInitTransferFromFrame(const RxFrameModel* const frame, Can
 }
 
 /// The implementation is borrowed from the Specification.
-CANARD_PRIVATE uint8_t rxComputeTransferIDDifference(const uint8_t a, const uint8_t b);
 CANARD_PRIVATE uint8_t rxComputeTransferIDDifference(const uint8_t a, const uint8_t b)
 {
     CANARD_ASSERT(a <= CANARD_TRANSFER_ID_MAX);
@@ -636,11 +597,6 @@ CANARD_PRIVATE uint8_t rxComputeTransferIDDifference(const uint8_t a, const uint
     return (uint8_t) diff;
 }
 
-CANARD_PRIVATE int8_t rxSessionWritePayload(CanardInstance* const          ins,
-                                            CanardInternalRxSession* const rxs,
-                                            const size_t                   extent,
-                                            const size_t                   payload_size,
-                                            const void* const              payload);
 CANARD_PRIVATE int8_t rxSessionWritePayload(CanardInstance* const          ins,
                                             CanardInternalRxSession* const rxs,
                                             const size_t                   extent,
@@ -693,7 +649,6 @@ CANARD_PRIVATE int8_t rxSessionWritePayload(CanardInstance* const          ins,
     return out;
 }
 
-CANARD_PRIVATE void rxSessionRestart(CanardInstance* const ins, CanardInternalRxSession* const rxs);
 CANARD_PRIVATE void rxSessionRestart(CanardInstance* const ins, CanardInternalRxSession* const rxs)
 {
     CANARD_ASSERT(ins != NULL);
@@ -708,11 +663,6 @@ CANARD_PRIVATE void rxSessionRestart(CanardInstance* const ins, CanardInternalRx
     rxs->toggle = INITIAL_TOGGLE_STATE;
 }
 
-CANARD_PRIVATE int8_t rxSessionAcceptFrame(CanardInstance* const          ins,
-                                           CanardInternalRxSession* const rxs,
-                                           const RxFrameModel* const      frame,
-                                           const size_t                   extent,
-                                           CanardTransfer* const          out_transfer);
 CANARD_PRIVATE int8_t rxSessionAcceptFrame(CanardInstance* const          ins,
                                            CanardInternalRxSession* const rxs,
                                            const RxFrameModel* const      frame,
@@ -789,13 +739,6 @@ CANARD_PRIVATE int8_t rxSessionUpdate(CanardInstance* const          ins,
                                       const uint8_t                  redundant_transport_index,
                                       const CanardMicrosecond        transfer_id_timeout_usec,
                                       const size_t                   extent,
-                                      CanardTransfer* const          out_transfer);
-CANARD_PRIVATE int8_t rxSessionUpdate(CanardInstance* const          ins,
-                                      CanardInternalRxSession* const rxs,
-                                      const RxFrameModel* const      frame,
-                                      const uint8_t                  redundant_transport_index,
-                                      const CanardMicrosecond        transfer_id_timeout_usec,
-                                      const size_t                   extent,
                                       CanardTransfer* const          out_transfer)
 {
     CANARD_ASSERT(ins != NULL);
@@ -841,11 +784,6 @@ CANARD_PRIVATE int8_t rxSessionUpdate(CanardInstance* const          ins,
     return out;
 }
 
-CANARD_PRIVATE int8_t rxAcceptFrame(CanardInstance* const       ins,
-                                    CanardRxSubscription* const subscription,
-                                    const RxFrameModel* const   frame,
-                                    const uint8_t               redundant_transport_index,
-                                    CanardTransfer* const       out_transfer);
 CANARD_PRIVATE int8_t rxAcceptFrame(CanardInstance* const       ins,
                                     CanardRxSubscription* const subscription,
                                     const RxFrameModel* const   frame,

--- a/libcanard/canard_dsdl.c
+++ b/libcanard/canard_dsdl.c
@@ -86,7 +86,7 @@ void canardDSDLCopyBits(const size_t      length_bit,
     CANARD_ASSERT((src != NULL) && (dst != NULL) && (src != dst));
     if ((0U == (src_offset_bit % BYTE_WIDTH)) && (0U == (dst_offset_bit % BYTE_WIDTH)))
     {
-        const size_t length_bytes = (size_t) (length_bit / BYTE_WIDTH);
+        const size_t length_bytes = (size_t)(length_bit / BYTE_WIDTH);
         // Intentional violation of MISRA: Pointer arithmetics. This is done to remove the API constraint that
         // offsets be under 8 bits. Fewer constraints reduce the chance of API misuse.
         const uint8_t* const psrc = (src_offset_bit / BYTE_WIDTH) + (const uint8_t*) src;  // NOSONAR NOLINT
@@ -94,15 +94,15 @@ void canardDSDLCopyBits(const size_t      length_bit,
         // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
         // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
         (void) memcpy(pdst, psrc, length_bytes);  // NOLINT
-        const uint8_t length_mod = (uint8_t) (length_bit % BYTE_WIDTH);
+        const uint8_t length_mod = (uint8_t)(length_bit % BYTE_WIDTH);
         if (0U != length_mod)  // If the length is unaligned, the last byte requires special treatment.
         {
             // Intentional violation of MISRA: Pointer arithmetics. It is unavoidable in this context.
             const uint8_t* const last_src = psrc + length_bytes;  // NOLINT NOSONAR
             uint8_t* const       last_dst = pdst + length_bytes;  // NOLINT NOSONAR
             CANARD_ASSERT(length_mod < BYTE_WIDTH);
-            const uint8_t mask = (uint8_t) ((1U << length_mod) - 1U);
-            *last_dst          = (uint8_t) (*last_dst & (uint8_t) ~mask) | (uint8_t) (*last_src & mask);
+            const uint8_t mask = (uint8_t)((1U << length_mod) - 1U);
+            *last_dst          = (uint8_t)(*last_dst & (uint8_t) ~mask) | (uint8_t)(*last_src & mask);
         }
     }
     else
@@ -117,21 +117,21 @@ void canardDSDLCopyBits(const size_t      length_bit,
         const size_t         last_bit = src_off + length_bit;
         while (last_bit > src_off)
         {
-            const uint8_t src_mod = (uint8_t) (src_off % BYTE_WIDTH);
-            const uint8_t dst_mod = (uint8_t) (dst_off % BYTE_WIDTH);
+            const uint8_t src_mod = (uint8_t)(src_off % BYTE_WIDTH);
+            const uint8_t dst_mod = (uint8_t)(dst_off % BYTE_WIDTH);
             const uint8_t max_mod = (src_mod > dst_mod) ? src_mod : dst_mod;
 
             const uint8_t size = (uint8_t) chooseMin(BYTE_WIDTH - max_mod, last_bit - src_off);
             CANARD_ASSERT((size > 0U) && (size <= BYTE_WIDTH));
 
             // Suppress a false warning from Clang-Tidy & Sonar that size is being over-shifted. It's not.
-            const uint8_t mask = (uint8_t) ((((1U << size) - 1U) << dst_mod) & BYTE_MAX);  // NOLINT NOSONAR
+            const uint8_t mask = (uint8_t)((((1U << size) - 1U) << dst_mod) & BYTE_MAX);  // NOLINT NOSONAR
             CANARD_ASSERT(mask > 0U);
 
             // Intentional violation of MISRA: indexing on a pointer.
             // This simplifies the implementation greatly and avoids pointer arithmetics.
             const uint8_t in =
-                (uint8_t) ((uint8_t) (psrc[src_off / BYTE_WIDTH] >> src_mod) << dst_mod) & BYTE_MAX;  // NOSONAR
+                (uint8_t)((uint8_t)(psrc[src_off / BYTE_WIDTH] >> src_mod) << dst_mod) & BYTE_MAX;  // NOSONAR
 
             // Intentional violation of MISRA: indexing on a pointer.
             // This simplifies the implementation greatly and avoids pointer arithmetics.
@@ -168,14 +168,14 @@ void canardDSDLSetUxx(uint8_t* const buf, const size_t off_bit, const uint64_t v
     canardDSDLCopyBits(saturated_len_bit, 0U, off_bit, (const uint8_t*) &value, buf);
 #else
     const uint8_t tmp[sizeof(uint64_t)] = {
-        (uint8_t) ((value >> 0U) & BYTE_MAX),   // Suppress warnings about the magic numbers. Their purpose is clear.
-        (uint8_t) ((value >> 8U) & BYTE_MAX),   // NOLINT NOSONAR
-        (uint8_t) ((value >> 16U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t) ((value >> 24U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t) ((value >> 32U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t) ((value >> 40U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t) ((value >> 48U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t) ((value >> 56U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 0U) & BYTE_MAX),   // Suppress warnings about the magic numbers. Their purpose is clear.
+        (uint8_t)((value >> 8U) & BYTE_MAX),   // NOLINT NOSONAR
+        (uint8_t)((value >> 16U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 24U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 32U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 40U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 48U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t)((value >> 56U) & BYTE_MAX),  // NOLINT NOSONAR
     };
     canardDSDLCopyBits(saturated_len_bit, 0U, off_bit, &tmp[0], buf);
 #endif
@@ -216,7 +216,7 @@ uint16_t canardDSDLGetU16(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint16_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint16_t) (tmp[0] | (uint16_t) (((uint16_t) tmp[1]) << BYTE_WIDTH));
+    return (uint16_t)(tmp[0] | (uint16_t)(((uint16_t) tmp[1]) << BYTE_WIDTH));
 #endif
 }
 
@@ -232,10 +232,10 @@ uint32_t canardDSDLGetU32(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint32_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint32_t) (tmp[0] |                      // Suppress warnings about the magic numbers.
-                       ((uint32_t) tmp[1] << 8U) |   // NOLINT NOSONAR
-                       ((uint32_t) tmp[2] << 16U) |  // NOLINT NOSONAR
-                       ((uint32_t) tmp[3] << 24U));  // NOLINT NOSONAR
+    return (uint32_t)(tmp[0] |                      // Suppress warnings about the magic numbers.
+                      ((uint32_t) tmp[1] << 8U) |   // NOLINT NOSONAR
+                      ((uint32_t) tmp[2] << 16U) |  // NOLINT NOSONAR
+                      ((uint32_t) tmp[3] << 24U));  // NOLINT NOSONAR
 #endif
 }
 
@@ -251,14 +251,14 @@ uint64_t canardDSDLGetU64(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint64_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint64_t) (tmp[0] |                      // Suppress warnings about the magic numbers.
-                       ((uint64_t) tmp[1] << 8U) |   // NOLINT NOSONAR
-                       ((uint64_t) tmp[2] << 16U) |  // NOLINT NOSONAR
-                       ((uint64_t) tmp[3] << 24U) |  // NOLINT NOSONAR
-                       ((uint64_t) tmp[4] << 32U) |  // NOLINT NOSONAR
-                       ((uint64_t) tmp[5] << 40U) |  // NOLINT NOSONAR
-                       ((uint64_t) tmp[6] << 48U) |  // NOLINT NOSONAR
-                       ((uint64_t) tmp[7] << 56U));  // NOLINT NOSONAR
+    return (uint64_t)(tmp[0] |                      // Suppress warnings about the magic numbers.
+                      ((uint64_t) tmp[1] << 8U) |   // NOLINT NOSONAR
+                      ((uint64_t) tmp[2] << 16U) |  // NOLINT NOSONAR
+                      ((uint64_t) tmp[3] << 24U) |  // NOLINT NOSONAR
+                      ((uint64_t) tmp[4] << 32U) |  // NOLINT NOSONAR
+                      ((uint64_t) tmp[5] << 40U) |  // NOLINT NOSONAR
+                      ((uint64_t) tmp[6] << 48U) |  // NOLINT NOSONAR
+                      ((uint64_t) tmp[7] << 56U));  // NOLINT NOSONAR
 #endif
 }
 
@@ -267,8 +267,8 @@ int8_t canardDSDLGetI8(const uint8_t* const buf, const size_t buf_size, const si
     const uint8_t sat = (uint8_t) chooseMin(len_bit, BYTE_WIDTH);
     uint8_t       val = canardDSDLGetU8(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < BYTE_WIDTH) && neg) ? (uint8_t) (val | ~((1U << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int8_t) ((-(int8_t) (uint8_t) ~val) - 1) : (int8_t) val;
+    val               = ((sat < BYTE_WIDTH) && neg) ? (uint8_t)(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int8_t)((-(int8_t)(uint8_t) ~val) - 1) : (int8_t) val;
 }
 
 int16_t canardDSDLGetI16(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -276,8 +276,8 @@ int16_t canardDSDLGetI16(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH16);
     uint16_t      val = canardDSDLGetU16(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH16) && neg) ? (uint16_t) (val | ~((1U << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int16_t) ((-(int16_t) (uint16_t) ~val) - 1) : (int16_t) val;
+    val               = ((sat < WIDTH16) && neg) ? (uint16_t)(val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int16_t)((-(int16_t)(uint16_t) ~val) - 1) : (int16_t) val;
 }
 
 int32_t canardDSDLGetI32(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -285,8 +285,8 @@ int32_t canardDSDLGetI32(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH32);
     uint32_t      val = canardDSDLGetU32(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH32) && neg) ? (uint32_t) (val | ~((1UL << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int32_t) ((-(int32_t) ~val) - 1) : (int32_t) val;
+    val               = ((sat < WIDTH32) && neg) ? (uint32_t)(val | ~((1UL << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int32_t)((-(int32_t) ~val) - 1) : (int32_t) val;
 }
 
 int64_t canardDSDLGetI64(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -294,8 +294,8 @@ int64_t canardDSDLGetI64(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH64);
     uint64_t      val = canardDSDLGetU64(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH64) && neg) ? (uint64_t) (val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int64_t) ((-(int64_t) ~val) - 1) : (int64_t) val;
+    val               = ((sat < WIDTH64) && neg) ? (uint64_t)(val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int64_t)((-(int64_t) ~val) - 1) : (int64_t) val;
 }
 
 // --------------------------------------------- PUBLIC API - FLOAT16 ---------------------------------------------
@@ -345,9 +345,9 @@ CANARD_PRIVATE uint16_t float16Pack(const CanardDSDLFloat32 value)
         {
             in.bits = f16inf.bits;
         }
-        out = (uint16_t) (in.bits >> 13U);  // NOLINT NOSONAR
+        out = (uint16_t)(in.bits >> 13U);  // NOLINT NOSONAR
     }
-    out |= (uint16_t) (sign >> 16U);  // NOLINT NOSONAR
+    out |= (uint16_t)(sign >> 16U);  // NOLINT NOSONAR
     return out;
 }
 
@@ -355,15 +355,15 @@ CANARD_PRIVATE CanardDSDLFloat32 float16Unpack(const uint16_t value)
 {
     // The no-lint statements suppress the warnings about magic numbers.
     // The no-lint statements suppress the warning about the use of union. This is required for low-level bit access.
-    const Float32Bits magic   = {.bits = ((uint32_t) 0xEFU) << 23U};              // NOLINT NOSONAR
-    const Float32Bits inf_nan = {.bits = ((uint32_t) 0x8FU) << 23U};              // NOLINT NOSONAR
-    Float32Bits       out     = {.bits = ((uint32_t) (value & 0x7FFFU)) << 13U};  // NOLINT NOSONAR
+    const Float32Bits magic   = {.bits = ((uint32_t) 0xEFU) << 23U};             // NOLINT NOSONAR
+    const Float32Bits inf_nan = {.bits = ((uint32_t) 0x8FU) << 23U};             // NOLINT NOSONAR
+    Float32Bits       out     = {.bits = ((uint32_t)(value & 0x7FFFU)) << 13U};  // NOLINT NOSONAR
     out.real *= magic.real;
     if (out.real >= inf_nan.real)
     {
         out.bits |= ((uint32_t) 0xFFU) << 23U;  // NOLINT NOSONAR
     }
-    out.bits |= ((uint32_t) (value & 0x8000U)) << 16U;  // NOLINT NOSONAR
+    out.bits |= ((uint32_t)(value & 0x8000U)) << 16U;  // NOLINT NOSONAR
     return out.real;
 }
 

--- a/libcanard/canard_dsdl.c
+++ b/libcanard/canard_dsdl.c
@@ -25,9 +25,7 @@
 #endif
 
 /// This macro is needed only for testing and for library development. Do not redefine this in production.
-#if defined(CANARD_CONFIG_EXPOSE_PRIVATE) && CANARD_CONFIG_EXPOSE_PRIVATE
-#    define CANARD_PRIVATE
-#else  // Consider defining an extra compilation option that turns this into "static inline"?
+#ifndef CANARD_PRIVATE
 #    define CANARD_PRIVATE static
 #endif
 
@@ -62,16 +60,11 @@
 
 // --------------------------------------------- PRIMITIVE SERIALIZATION ---------------------------------------------
 
-CANARD_PRIVATE size_t chooseMin(size_t a, size_t b);
 CANARD_PRIVATE size_t chooseMin(size_t a, size_t b)
 {
     return (a < b) ? a : b;
 }
 
-CANARD_PRIVATE size_t getBitCopySize(const size_t  buf_size_bytes,
-                                     const size_t  offset_bit,
-                                     const size_t  requested_length_bit,
-                                     const uint8_t value_length_bit);
 CANARD_PRIVATE size_t getBitCopySize(const size_t  buf_size_bytes,
                                      const size_t  offset_bit,
                                      const size_t  requested_length_bit,
@@ -93,7 +86,7 @@ void canardDSDLCopyBits(const size_t      length_bit,
     CANARD_ASSERT((src != NULL) && (dst != NULL) && (src != dst));
     if ((0U == (src_offset_bit % BYTE_WIDTH)) && (0U == (dst_offset_bit % BYTE_WIDTH)))
     {
-        const size_t length_bytes = (size_t)(length_bit / BYTE_WIDTH);
+        const size_t length_bytes = (size_t) (length_bit / BYTE_WIDTH);
         // Intentional violation of MISRA: Pointer arithmetics. This is done to remove the API constraint that
         // offsets be under 8 bits. Fewer constraints reduce the chance of API misuse.
         const uint8_t* const psrc = (src_offset_bit / BYTE_WIDTH) + (const uint8_t*) src;  // NOSONAR NOLINT
@@ -101,15 +94,15 @@ void canardDSDLCopyBits(const size_t      length_bit,
         // Clang-Tidy raises an error recommending the use of memcpy_s() instead.
         // We ignore it because the safe functions are poorly supported; reliance on them may limit the portability.
         (void) memcpy(pdst, psrc, length_bytes);  // NOLINT
-        const uint8_t length_mod = (uint8_t)(length_bit % BYTE_WIDTH);
+        const uint8_t length_mod = (uint8_t) (length_bit % BYTE_WIDTH);
         if (0U != length_mod)  // If the length is unaligned, the last byte requires special treatment.
         {
             // Intentional violation of MISRA: Pointer arithmetics. It is unavoidable in this context.
             const uint8_t* const last_src = psrc + length_bytes;  // NOLINT NOSONAR
             uint8_t* const       last_dst = pdst + length_bytes;  // NOLINT NOSONAR
             CANARD_ASSERT(length_mod < BYTE_WIDTH);
-            const uint8_t mask = (uint8_t)((1U << length_mod) - 1U);
-            *last_dst          = (uint8_t)(*last_dst & (uint8_t) ~mask) | (uint8_t)(*last_src & mask);
+            const uint8_t mask = (uint8_t) ((1U << length_mod) - 1U);
+            *last_dst          = (uint8_t) (*last_dst & (uint8_t) ~mask) | (uint8_t) (*last_src & mask);
         }
     }
     else
@@ -124,21 +117,21 @@ void canardDSDLCopyBits(const size_t      length_bit,
         const size_t         last_bit = src_off + length_bit;
         while (last_bit > src_off)
         {
-            const uint8_t src_mod = (uint8_t)(src_off % BYTE_WIDTH);
-            const uint8_t dst_mod = (uint8_t)(dst_off % BYTE_WIDTH);
+            const uint8_t src_mod = (uint8_t) (src_off % BYTE_WIDTH);
+            const uint8_t dst_mod = (uint8_t) (dst_off % BYTE_WIDTH);
             const uint8_t max_mod = (src_mod > dst_mod) ? src_mod : dst_mod;
 
             const uint8_t size = (uint8_t) chooseMin(BYTE_WIDTH - max_mod, last_bit - src_off);
             CANARD_ASSERT((size > 0U) && (size <= BYTE_WIDTH));
 
             // Suppress a false warning from Clang-Tidy & Sonar that size is being over-shifted. It's not.
-            const uint8_t mask = (uint8_t)((((1U << size) - 1U) << dst_mod) & BYTE_MAX);  // NOLINT NOSONAR
+            const uint8_t mask = (uint8_t) ((((1U << size) - 1U) << dst_mod) & BYTE_MAX);  // NOLINT NOSONAR
             CANARD_ASSERT(mask > 0U);
 
             // Intentional violation of MISRA: indexing on a pointer.
             // This simplifies the implementation greatly and avoids pointer arithmetics.
             const uint8_t in =
-                (uint8_t)((uint8_t)(psrc[src_off / BYTE_WIDTH] >> src_mod) << dst_mod) & BYTE_MAX;  // NOSONAR
+                (uint8_t) ((uint8_t) (psrc[src_off / BYTE_WIDTH] >> src_mod) << dst_mod) & BYTE_MAX;  // NOSONAR
 
             // Intentional violation of MISRA: indexing on a pointer.
             // This simplifies the implementation greatly and avoids pointer arithmetics.
@@ -175,14 +168,14 @@ void canardDSDLSetUxx(uint8_t* const buf, const size_t off_bit, const uint64_t v
     canardDSDLCopyBits(saturated_len_bit, 0U, off_bit, (const uint8_t*) &value, buf);
 #else
     const uint8_t tmp[sizeof(uint64_t)] = {
-        (uint8_t)((value >> 0U) & BYTE_MAX),   // Suppress warnings about the magic numbers. Their purpose is clear.
-        (uint8_t)((value >> 8U) & BYTE_MAX),   // NOLINT NOSONAR
-        (uint8_t)((value >> 16U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t)((value >> 24U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t)((value >> 32U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t)((value >> 40U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t)((value >> 48U) & BYTE_MAX),  // NOLINT NOSONAR
-        (uint8_t)((value >> 56U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 0U) & BYTE_MAX),   // Suppress warnings about the magic numbers. Their purpose is clear.
+        (uint8_t) ((value >> 8U) & BYTE_MAX),   // NOLINT NOSONAR
+        (uint8_t) ((value >> 16U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 24U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 32U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 40U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 48U) & BYTE_MAX),  // NOLINT NOSONAR
+        (uint8_t) ((value >> 56U) & BYTE_MAX),  // NOLINT NOSONAR
     };
     canardDSDLCopyBits(saturated_len_bit, 0U, off_bit, &tmp[0], buf);
 #endif
@@ -223,7 +216,7 @@ uint16_t canardDSDLGetU16(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint16_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint16_t)(tmp[0] | (uint16_t)(((uint16_t) tmp[1]) << BYTE_WIDTH));
+    return (uint16_t) (tmp[0] | (uint16_t) (((uint16_t) tmp[1]) << BYTE_WIDTH));
 #endif
 }
 
@@ -239,10 +232,10 @@ uint32_t canardDSDLGetU32(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint32_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint32_t)(tmp[0] |                      // Suppress warnings about the magic numbers.
-                      ((uint32_t) tmp[1] << 8U) |   // NOLINT NOSONAR
-                      ((uint32_t) tmp[2] << 16U) |  // NOLINT NOSONAR
-                      ((uint32_t) tmp[3] << 24U));  // NOLINT NOSONAR
+    return (uint32_t) (tmp[0] |                      // Suppress warnings about the magic numbers.
+                       ((uint32_t) tmp[1] << 8U) |   // NOLINT NOSONAR
+                       ((uint32_t) tmp[2] << 16U) |  // NOLINT NOSONAR
+                       ((uint32_t) tmp[3] << 24U));  // NOLINT NOSONAR
 #endif
 }
 
@@ -258,14 +251,14 @@ uint64_t canardDSDLGetU64(const uint8_t* const buf, const size_t buf_size, const
 #else
     uint8_t tmp[sizeof(uint64_t)] = {0};
     canardDSDLCopyBits(copy_size, off_bit, 0U, buf, &tmp[0]);
-    return (uint64_t)(tmp[0] |                      // Suppress warnings about the magic numbers.
-                      ((uint64_t) tmp[1] << 8U) |   // NOLINT NOSONAR
-                      ((uint64_t) tmp[2] << 16U) |  // NOLINT NOSONAR
-                      ((uint64_t) tmp[3] << 24U) |  // NOLINT NOSONAR
-                      ((uint64_t) tmp[4] << 32U) |  // NOLINT NOSONAR
-                      ((uint64_t) tmp[5] << 40U) |  // NOLINT NOSONAR
-                      ((uint64_t) tmp[6] << 48U) |  // NOLINT NOSONAR
-                      ((uint64_t) tmp[7] << 56U));  // NOLINT NOSONAR
+    return (uint64_t) (tmp[0] |                      // Suppress warnings about the magic numbers.
+                       ((uint64_t) tmp[1] << 8U) |   // NOLINT NOSONAR
+                       ((uint64_t) tmp[2] << 16U) |  // NOLINT NOSONAR
+                       ((uint64_t) tmp[3] << 24U) |  // NOLINT NOSONAR
+                       ((uint64_t) tmp[4] << 32U) |  // NOLINT NOSONAR
+                       ((uint64_t) tmp[5] << 40U) |  // NOLINT NOSONAR
+                       ((uint64_t) tmp[6] << 48U) |  // NOLINT NOSONAR
+                       ((uint64_t) tmp[7] << 56U));  // NOLINT NOSONAR
 #endif
 }
 
@@ -274,8 +267,8 @@ int8_t canardDSDLGetI8(const uint8_t* const buf, const size_t buf_size, const si
     const uint8_t sat = (uint8_t) chooseMin(len_bit, BYTE_WIDTH);
     uint8_t       val = canardDSDLGetU8(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < BYTE_WIDTH) && neg) ? (uint8_t)(val | ~((1U << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int8_t)((-(int8_t)(uint8_t) ~val) - 1) : (int8_t) val;
+    val               = ((sat < BYTE_WIDTH) && neg) ? (uint8_t) (val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int8_t) ((-(int8_t) (uint8_t) ~val) - 1) : (int8_t) val;
 }
 
 int16_t canardDSDLGetI16(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -283,8 +276,8 @@ int16_t canardDSDLGetI16(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH16);
     uint16_t      val = canardDSDLGetU16(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH16) && neg) ? (uint16_t)(val | ~((1U << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int16_t)((-(int16_t)(uint16_t) ~val) - 1) : (int16_t) val;
+    val               = ((sat < WIDTH16) && neg) ? (uint16_t) (val | ~((1U << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int16_t) ((-(int16_t) (uint16_t) ~val) - 1) : (int16_t) val;
 }
 
 int32_t canardDSDLGetI32(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -292,8 +285,8 @@ int32_t canardDSDLGetI32(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH32);
     uint32_t      val = canardDSDLGetU32(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH32) && neg) ? (uint32_t)(val | ~((1UL << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int32_t)((-(int32_t) ~val) - 1) : (int32_t) val;
+    val               = ((sat < WIDTH32) && neg) ? (uint32_t) (val | ~((1UL << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int32_t) ((-(int32_t) ~val) - 1) : (int32_t) val;
 }
 
 int64_t canardDSDLGetI64(const uint8_t* const buf, const size_t buf_size, const size_t off_bit, const uint8_t len_bit)
@@ -301,8 +294,8 @@ int64_t canardDSDLGetI64(const uint8_t* const buf, const size_t buf_size, const 
     const uint8_t sat = (uint8_t) chooseMin(len_bit, WIDTH64);
     uint64_t      val = canardDSDLGetU64(buf, buf_size, off_bit, sat);
     const bool    neg = (sat > 0U) && ((val & (1ULL << (sat - 1U))) != 0U);
-    val               = ((sat < WIDTH64) && neg) ? (uint64_t)(val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
-    return neg ? (int64_t)((-(int64_t) ~val) - 1) : (int64_t) val;
+    val               = ((sat < WIDTH64) && neg) ? (uint64_t) (val | ~((1ULL << sat) - 1U)) : val;  // Sign extension
+    return neg ? (int64_t) ((-(int64_t) ~val) - 1) : (int64_t) val;
 }
 
 // --------------------------------------------- PUBLIC API - FLOAT16 ---------------------------------------------
@@ -319,7 +312,6 @@ typedef union  // NOSONAR
     CanardDSDLFloat32 real;
 } Float32Bits;
 
-CANARD_PRIVATE uint16_t float16Pack(const CanardDSDLFloat32 value);
 CANARD_PRIVATE uint16_t float16Pack(const CanardDSDLFloat32 value)
 {
     // The no-lint statements suppress the warnings about magic numbers.
@@ -353,26 +345,25 @@ CANARD_PRIVATE uint16_t float16Pack(const CanardDSDLFloat32 value)
         {
             in.bits = f16inf.bits;
         }
-        out = (uint16_t)(in.bits >> 13U);  // NOLINT NOSONAR
+        out = (uint16_t) (in.bits >> 13U);  // NOLINT NOSONAR
     }
-    out |= (uint16_t)(sign >> 16U);  // NOLINT NOSONAR
+    out |= (uint16_t) (sign >> 16U);  // NOLINT NOSONAR
     return out;
 }
 
-CANARD_PRIVATE CanardDSDLFloat32 float16Unpack(const uint16_t value);
 CANARD_PRIVATE CanardDSDLFloat32 float16Unpack(const uint16_t value)
 {
     // The no-lint statements suppress the warnings about magic numbers.
     // The no-lint statements suppress the warning about the use of union. This is required for low-level bit access.
-    const Float32Bits magic   = {.bits = ((uint32_t) 0xEFU) << 23U};             // NOLINT NOSONAR
-    const Float32Bits inf_nan = {.bits = ((uint32_t) 0x8FU) << 23U};             // NOLINT NOSONAR
-    Float32Bits       out     = {.bits = ((uint32_t)(value & 0x7FFFU)) << 13U};  // NOLINT NOSONAR
+    const Float32Bits magic   = {.bits = ((uint32_t) 0xEFU) << 23U};              // NOLINT NOSONAR
+    const Float32Bits inf_nan = {.bits = ((uint32_t) 0x8FU) << 23U};              // NOLINT NOSONAR
+    Float32Bits       out     = {.bits = ((uint32_t) (value & 0x7FFFU)) << 13U};  // NOLINT NOSONAR
     out.real *= magic.real;
     if (out.real >= inf_nan.real)
     {
         out.bits |= ((uint32_t) 0xFFU) << 23U;  // NOLINT NOSONAR
     }
-    out.bits |= ((uint32_t)(value & 0x8000U)) << 16U;  // NOLINT NOSONAR
+    out.bits |= ((uint32_t) (value & 0x8000U)) << 16U;  // NOLINT NOSONAR
     return out.real;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ if (NOT NO_STATIC_ANALYSIS)
     set(CMAKE_CXX_CLANG_TIDY ${clang_tidy})
 
     # clang-format
-    find_program(clang_format NAMES clang-format-12 clang-format-11 clang-format-10 clang-format)
+    find_program(clang_format NAMES clang-format-12 clang-format-11 clang-format)
     if (NOT clang_format)
         message(FATAL_ERROR "Could not locate clang-format")
     endif ()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,27 +64,36 @@ function(gen_test name files compile_definitions compile_flags link_flags c_stan
     add_test("run_${name}" "${name}" --rng-seed time)
 endfunction()
 
-function(gen_test_matrix name files compile_definitions)
-    gen_test("${name}_x64_c99" "${files}" "${compile_definitions}" "-m64" "-m64" "99")
-    gen_test("${name}_x32_c99" "${files}" "${compile_definitions}" "-m32" "-m32" "99")
-    gen_test("${name}_x64_c11" "${files}" "${compile_definitions}" "-m64" "-m64" "11")
-    gen_test("${name}_x32_c11" "${files}" "${compile_definitions}" "-m32" "-m32" "11")
+function(gen_test_matrix name files compile_definitions compile_flags)
+    gen_test("${name}_x64_c99" "${files}" "${compile_definitions}" "${compile_flags} -m64" "-m64" "99")
+    gen_test("${name}_x32_c99" "${files}" "${compile_definitions}" "${compile_flags} -m32" "-m32" "99")
+    gen_test("${name}_x64_c11" "${files}" "${compile_definitions}" "${compile_flags} -m64" "-m64" "11")
+    gen_test("${name}_x32_c11" "${files}" "${compile_definitions}" "${compile_flags} -m32" "-m32" "11")
     # Coverage is only available for GCC builds.
     if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_BUILD_TYPE STREQUAL "Debug"))
-        gen_test("${name}_cov" "${files}" "${compile_definitions}" "-g -O0 --coverage" "--coverage" "11")
+        gen_test("${name}_cov"
+                 "${files}"
+                 "${compile_definitions}"
+                 "${compile_flags} -g -O0 --coverage"
+                 "--coverage"
+                 "11")
     endif ()
 endfunction()
 
+# Disable missing declaration warning to allow exposure of private definitions.
 gen_test_matrix(test_private
                 "test_private_crc.cpp;test_private_rx.cpp;test_private_tx.cpp;test_dsdl.cpp"
-                CANARD_CONFIG_EXPOSE_PRIVATE=1)
+                "CANARD_PRIVATE="
+                "-Wno-missing-declarations")
 
 # We assume here that the target platform is little-endian. If it's not, the test will fail.
 # Perhaps this needs fixing: these tests need not be run if the target is not little-endian.
 gen_test_matrix(test_private_le
                 "test_private_crc.cpp;test_private_rx.cpp;test_private_tx.cpp;test_dsdl.cpp"
-                "CANARD_CONFIG_EXPOSE_PRIVATE=1;CANARD_DSDL_CONFIG_LITTLE_ENDIAN=1")
+                "CANARD_PRIVATE=;CANARD_DSDL_CONFIG_LITTLE_ENDIAN=1"
+                "-Wno-missing-declarations")
 
 gen_test_matrix(test_public
                 "test_public_tx.cpp;test_public_rx.cpp;test_public_roundtrip.cpp;test_self.cpp"
+                ""
                 "")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(library_dir "${CMAKE_SOURCE_DIR}/../libcanard")
 # If not suppressed, the tools used here shall be available, otherwise the build will fail.
 if (NOT NO_STATIC_ANALYSIS)
     # clang-tidy (separate config files per directory)
-    find_program(clang_tidy NAMES clang-tidy-12 clang-tidy-11 clang-tidy-10 clang-tidy)
+    find_program(clang_tidy NAMES clang-tidy-12 clang-tidy-11 clang-tidy)
     if (NOT clang_tidy)
         message(FATAL_ERROR "Could not locate clang-tidy")
     endif ()

--- a/tests/exposed.hpp
+++ b/tests/exposed.hpp
@@ -39,7 +39,7 @@ struct TxQueueItem final
     TxQueueItem(const TxQueueItem&)  = delete;
     TxQueueItem(const TxQueueItem&&) = delete;
     auto operator=(const TxQueueItem&) -> TxQueueItem& = delete;
-    auto operator=(const TxQueueItem &&) -> TxQueueItem& = delete;
+    auto operator=(const TxQueueItem&&) -> TxQueueItem& = delete;
 };
 
 struct RxSession

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -59,7 +59,7 @@ public:
     TestAllocator(const TestAllocator&)  = delete;
     TestAllocator(const TestAllocator&&) = delete;
     auto operator=(const TestAllocator&) -> TestAllocator& = delete;
-    auto operator=(const TestAllocator &&) -> TestAllocator& = delete;
+    auto operator=(const TestAllocator&&) -> TestAllocator& = delete;
 
     virtual ~TestAllocator()
     {
@@ -166,7 +166,7 @@ public:
     Instance(const Instance&)  = delete;
     Instance(const Instance&&) = delete;
     auto operator=(const Instance&) -> Instance& = delete;
-    auto operator=(const Instance &&) -> Instance& = delete;
+    auto operator=(const Instance&&) -> Instance& = delete;
 
     [[nodiscard]] auto txPush(const CanardTransfer& transfer) { return canardTxPush(&canard_, &transfer); }
 

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -176,9 +176,11 @@ public:
 
     [[nodiscard]] auto rxAccept(const CanardFrame& frame,
                                 const uint8_t      redundant_transport_index,
-                                CanardTransfer&    out_transfer)
+                                CanardTransfer&    out_transfer,
+                                CanardRxSubscription** const out_subscription
+                               )
     {
-        return canardRxAccept(&canard_, &frame, redundant_transport_index, &out_transfer);
+        return canardRxAccept2(&canard_, &frame, redundant_transport_index, &out_transfer, out_subscription);
     }
 
     [[nodiscard]] auto rxSubscribe(const CanardTransferKind transfer_kind,

--- a/tests/helpers.hpp
+++ b/tests/helpers.hpp
@@ -174,11 +174,10 @@ public:
 
     void txPop() { canardTxPop(&canard_); }
 
-    [[nodiscard]] auto rxAccept(const CanardFrame& frame,
-                                const uint8_t      redundant_transport_index,
-                                CanardTransfer&    out_transfer,
-                                CanardRxSubscription** const out_subscription
-                               )
+    [[nodiscard]] auto rxAccept(const CanardFrame&           frame,
+                                const uint8_t                redundant_transport_index,
+                                CanardTransfer&              out_transfer,
+                                CanardRxSubscription** const out_subscription)
     {
         return canardRxAccept2(&canard_, &frame, redundant_transport_index, &out_transfer, out_subscription);
     }

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -153,8 +153,9 @@ TEST_CASE("RoundtripSimple")
                          << '\n';
 
                 CanardTransfer transfer{};
-                std::int8_t    result = ins_rx.rxAccept(*frame, 0, transfer);
-                REQUIRE(0 == ins_rx.rxAccept(*frame, 1, transfer));  // Redundant interface will never be used here.
+                CanardRxSubscription *subscription = nullptr;
+                std::int8_t    result = ins_rx.rxAccept(*frame, 0, transfer, &subscription);
+                REQUIRE(0 == ins_rx.rxAccept(*frame, 1, transfer, &subscription));  // Redundant interface will never be used here.
                 if (result == 1)
                 {
                     CanardTransfer reference{};  // Fetch the reference transfer from the list of pending.

--- a/tests/test_public_roundtrip.cpp
+++ b/tests/test_public_roundtrip.cpp
@@ -152,10 +152,13 @@ TEST_CASE("RoundtripSimple")
                          << " " << std::uint16_t(tail & 31U)                                                      //
                          << '\n';
 
-                CanardTransfer transfer{};
-                CanardRxSubscription *subscription = nullptr;
-                std::int8_t    result = ins_rx.rxAccept(*frame, 0, transfer, &subscription);
-                REQUIRE(0 == ins_rx.rxAccept(*frame, 1, transfer, &subscription));  // Redundant interface will never be used here.
+                CanardTransfer        transfer{};
+                CanardRxSubscription* subscription = nullptr;
+                std::int8_t           result       = ins_rx.rxAccept(*frame, 0, transfer, &subscription);
+                REQUIRE(0 == ins_rx.rxAccept(*frame,
+                                             1,
+                                             transfer,
+                                             &subscription));  // Redundant interface will never be used here.
                 if (result == 1)
                 {
                     CanardTransfer reference{};  // Fetch the reference transfer from the list of pending.

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -17,9 +17,9 @@ TEST_CASE("RxBasic0")
     using helpers::Instance;
     using exposed::RxSession;
 
-    Instance       ins;
-    CanardTransfer transfer{};
-    CanardRxSubscription *subscription = nullptr;
+    Instance              ins;
+    CanardTransfer        transfer{};
+    CanardRxSubscription* subscription = nullptr;
 
     const auto accept = [&](const std::uint8_t               redundant_transport_index,
                             const CanardMicrosecond          timestamp_usec,
@@ -155,7 +155,7 @@ TEST_CASE("RxBasic0")
     subscription = nullptr;
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00001}));
-    REQUIRE(subscription != nullptr); // Subscription get assigned before error code
+    REQUIRE(subscription != nullptr);  // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
 
@@ -164,7 +164,7 @@ TEST_CASE("RxBasic0")
     subscription = nullptr;
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00010}));
-    REQUIRE(subscription != nullptr); // Subscription get assigned before error code
+    REQUIRE(subscription != nullptr);  // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 5);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (3 * sizeof(RxSession) + 16 + 20));
 
@@ -216,9 +216,9 @@ TEST_CASE("RxAnonymous")
     using helpers::Instance;
     using exposed::RxSession;
 
-    Instance       ins;
-    CanardTransfer transfer{};
-    CanardRxSubscription *subscription = nullptr;
+    Instance              ins;
+    CanardTransfer        transfer{};
+    CanardRxSubscription* subscription = nullptr;
 
     const auto accept = [&](const std::uint8_t               redundant_transport_index,
                             const CanardMicrosecond          timestamp_usec,

--- a/tests/test_public_rx.cpp
+++ b/tests/test_public_rx.cpp
@@ -19,6 +19,7 @@ TEST_CASE("RxBasic0")
 
     Instance       ins;
     CanardTransfer transfer{};
+    CanardRxSubscription *subscription = nullptr;
 
     const auto accept = [&](const std::uint8_t               redundant_transport_index,
                             const CanardMicrosecond          timestamp_usec,
@@ -31,7 +32,7 @@ TEST_CASE("RxBasic0")
         frame.extended_can_id = extended_can_id;
         frame.payload_size    = std::size(payload);
         frame.payload         = payload_storage.data();
-        return ins.rxAccept(frame, redundant_transport_index, transfer);
+        return ins.rxAccept(frame, redundant_transport_index, transfer, &subscription);
     };
 
     ins.getAllocator().setAllocationCeiling(sizeof(RxSession) + 16);  // A session and a 16-byte payload buffer.
@@ -42,7 +43,9 @@ TEST_CASE("RxBasic0")
     REQUIRE(ins.getInstance()._rx_subscriptions[2] == nullptr);
 
     // A valid single-frame transfer for which there is no subscription.
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 100'000'000, 0b001'00'0'11'0110011001100'0'0100111, {0b111'00000}));
+    REQUIRE(subscription == nullptr);
 
     // Create a message subscription.
     CanardRxSubscription sub_msg{};
@@ -94,7 +97,10 @@ TEST_CASE("RxBasic0")
     REQUIRE(ins.getInstance()._rx_subscriptions[2] == &sub_req);
 
     // Accepted message.
+    subscription = nullptr;
     REQUIRE(1 == accept(0, 100'000'001, 0b001'00'0'11'0110011001100'0'0100111, {0b111'00000}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0110011001100);
     REQUIRE(transfer.timestamp_usec == 100'000'001);
     REQUIRE(transfer.priority == CanardPriorityImmediate);
     REQUIRE(transfer.transfer_kind == CanardTransferKindMessage);
@@ -112,14 +118,21 @@ TEST_CASE("RxBasic0")
     ins.getAllocator().setAllocationCeiling(sizeof(RxSession) * 2 + 16 + 20);
 
     // Dropped request because the local node does not have a node-ID.
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 100'000'002, 0b011'11'0000110011'0011010'0100111, {0b111'00010}));
+    REQUIRE(subscription == nullptr);
 
     // Dropped request because the local node has a different node-ID.
     ins.setNodeID(0b0011010);
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 100'000'002, 0b011'11'0000110011'0011011'0100111, {0b111'00011}));
+    REQUIRE(subscription == nullptr);
 
     // Same request accepted now.
+    subscription = nullptr;
     REQUIRE(1 == accept(0, 100'000'002, 0b011'11'0000110011'0011010'0100101, {1, 2, 3, 0b111'00100}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0000110011);
     REQUIRE(transfer.timestamp_usec == 100'000'002);
     REQUIRE(transfer.priority == CanardPriorityHigh);
     REQUIRE(transfer.transfer_kind == CanardTransferKindRequest);
@@ -134,18 +147,24 @@ TEST_CASE("RxBasic0")
 
     // Response transfer not accepted because the local node has a different node-ID.
     // There is no dynamic memory available, but it doesn't matter because a rejection does not require allocation.
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 100'000'002, 0b100'10'0000110011'0100111'0011011, {10, 20, 30, 0b111'00000}));
+    REQUIRE(subscription == nullptr);
 
     // Response transfer not accepted due to OOM -- can't allocate RX session.
+    subscription = nullptr;
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00001}));
+    REQUIRE(subscription != nullptr); // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 4);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 16 + 20));
 
     // Response transfer not accepted due to OOM -- can't allocate the buffer (RX session is allocated OK).
     ins.getAllocator().setAllocationCeiling(3 * sizeof(RxSession) + 16 + 20);
+    subscription = nullptr;
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00010}));
+    REQUIRE(subscription != nullptr); // Subscription get assigned before error code
     REQUIRE(ins.getAllocator().getNumAllocatedFragments() == 5);
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (3 * sizeof(RxSession) + 16 + 20));
 
@@ -159,7 +178,10 @@ TEST_CASE("RxBasic0")
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == (2 * sizeof(RxSession) + 20));
 
     // Same response accepted now. We have to keep incrementing the transfer-ID though because it's tracked.
+    subscription = nullptr;
     REQUIRE(1 == accept(0, 100'000'003, 0b100'10'0000111100'0011010'0011011, {5, 0b111'00011}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0000111100);
     REQUIRE(transfer.timestamp_usec == 100'000'003);
     REQUIRE(transfer.priority == CanardPriorityNominal);
     REQUIRE(transfer.transfer_kind == CanardTransferKindResponse);
@@ -173,8 +195,12 @@ TEST_CASE("RxBasic0")
     REQUIRE(ins.getInstance()._rx_subscriptions[1]->_next->_sessions[0b0011011] != nullptr);
 
     // Bad frames shall be rejected silently.
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 900'000'000, 0b100'10'0000111100'0011010'0011011, {5, 0b110'00011}));
+    REQUIRE(subscription == nullptr);
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 900'000'001, 0b100'10'0000111100'0011010'0011011, {}));
+    REQUIRE(subscription == nullptr);
 
     // Unsubscribe.
     REQUIRE(1 == ins.rxUnsubscribe(CanardTransferKindRequest, 0b0000110011));
@@ -192,6 +218,7 @@ TEST_CASE("RxAnonymous")
 
     Instance       ins;
     CanardTransfer transfer{};
+    CanardRxSubscription *subscription = nullptr;
 
     const auto accept = [&](const std::uint8_t               redundant_transport_index,
                             const CanardMicrosecond          timestamp_usec,
@@ -204,23 +231,28 @@ TEST_CASE("RxAnonymous")
         frame.extended_can_id = extended_can_id;
         frame.payload_size    = std::size(payload);
         frame.payload         = payload_storage.data();
-        return ins.rxAccept(frame, redundant_transport_index, transfer);
+        return ins.rxAccept(frame, redundant_transport_index, transfer, &subscription);
     };
 
     ins.getAllocator().setAllocationCeiling(16);
 
     // A valid anonymous transfer for which there is no subscription.
+    subscription = nullptr;
     REQUIRE(0 == accept(0, 100'000'000, 0b001'01'0'11'0110011001100'0'0100111, {0b111'00000}));
+    REQUIRE(subscription == nullptr);
 
     // Create a message subscription.
     CanardRxSubscription sub_msg{};
     REQUIRE(1 == ins.rxSubscribe(CanardTransferKindMessage, 0b0110011001100, 16, 2'000'000, sub_msg));  // New.
 
     // Accepted anonymous message.
+    subscription = nullptr;
     REQUIRE(1 == accept(0,
                         100'000'001,
                         0b001'01'0'11'0110011001100'0'0100111,  //
                         {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0b111'00000}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0110011001100);
     REQUIRE(transfer.timestamp_usec == 100'000'001);
     REQUIRE(transfer.priority == CanardPriorityImmediate);
     REQUIRE(transfer.transfer_kind == CanardTransferKindMessage);
@@ -236,6 +268,8 @@ TEST_CASE("RxAnonymous")
     // Anonymous message not accepted because OOM. The transfer shall remain unmodified by the call, so we re-check it.
     REQUIRE(-CANARD_ERROR_OUT_OF_MEMORY ==
             accept(0, 100'000'001, 0b001'01'0'11'0110011001100'0'0100111, {3, 2, 1, 0b111'00000}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0110011001100);
     REQUIRE(transfer.timestamp_usec == 100'000'001);
     REQUIRE(transfer.priority == CanardPriorityImmediate);
     REQUIRE(transfer.transfer_kind == CanardTransferKindMessage);
@@ -254,7 +288,10 @@ TEST_CASE("RxAnonymous")
     REQUIRE(ins.getAllocator().getTotalAllocatedAmount() == 0);
 
     // Accepted anonymous message with small payload.
+    subscription = nullptr;
     REQUIRE(1 == accept(0, 100'000'001, 0b001'01'0'11'0110011001100'0'0100111, {1, 2, 3, 4, 5, 6, 0b111'00000}));
+    REQUIRE(subscription != nullptr);
+    REQUIRE(subscription->_port_id == 0b0110011001100);
     REQUIRE(transfer.timestamp_usec == 100'000'001);
     REQUIRE(transfer.priority == CanardPriorityImmediate);
     REQUIRE(transfer.transfer_kind == CanardTransferKindMessage);


### PR DESCRIPTION
- Fix #163
- Update Clang-Tools to v11:
  - More consistent autoformatting (hide whitespace changes to declutter the diff)
  - New checks in clang-tidy
- Remove redundant declarations before static functions by improving the build flag handling in the test suite
- CI broke due to external factors; this PR fixes it
- Bump minor version number

Backward compatibility not affected

Context https://forum.uavcan.org/t/libcanard-calling-canardrxaccept-handler-in-o-1-time/1257