### PR TITLE
add acceptance filter configuration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,29 @@ else
 }
 ```
 
+A simple API for generating CAN hardware acceptance filter configurations is also provided.
+Acceptance filters are generated in an extended 29-bit ID + mask scheme and can be used to minimize the number of irrelevant transfers processed in software.
+
+```c
+// Generate an acceptance filter to receive only uavcan.node.Heartbeat.1.0 messages (fixed port ID 7509):
+CanardAcceptanceFilterConfig heartbeat_config = canardMakeAcceptanceFilterConfigForSubject(7509);
+// And to receive only uavcan.register.Access.1.0 services (fixed port ID 384):
+CanardAcceptanceFilterConfig register_access_config = canardMakeAcceptanceFilterConfigForService(384, ins.node_id);
+
+// You can also combine the two filter configurations into one (may also accept in other messages).
+// This allows consolidating a large set of configurations to fit the number of hardware filters.
+// For more information on the optimal subset of configurations to consolidate to minimize wasted CPU,
+// see the UAVCAN specification.
+CanardAcceptanceFilterConfig combined_config = canardConsolidateAcceptanceFilterConfigs(&heartbeat_config, &register_access_config);
+configureHardwareFilters(combined_config.extended_can_id, combined_config.extended_mask);
+```
+
+Full API specification is available in the documentation.
+If you find the examples to be unclear or incorrect, please, open a ticket.
+
 ## Revisions
 
 ### v2.0
-
 - Dedicated transmission queues per redundant CAN interface with depth limits.
   The application is now expected to instantiate `CanardTxQueue` (or several in case of redundant transport) manually.
 
@@ -224,6 +243,8 @@ else
 - `canardRxAccept2()` renamed to `canardRxAccept()`.
 
 - Support build configuration headers via `CANARD_CONFIG_HEADER`.
+
+- Add API for generating CAN hardware acceptance filter configurations
 
 ### v1.1
 

--- a/libcanard/canard.c
+++ b/libcanard/canard.c
@@ -1166,3 +1166,45 @@ int8_t canardRxUnsubscribe(CanardInstance* const    ins,
     }
     return out;
 }
+
+CanardFilter canardMakeFilterForSubject(const CanardPortID subject_id)
+{
+    CanardFilter out = {0};
+
+    out.extended_can_id = ((uint32_t) subject_id) << OFFSET_SUBJECT_ID;
+    out.extended_mask   = FLAG_SERVICE_NOT_MESSAGE | FLAG_RESERVED_07 | (CANARD_SUBJECT_ID_MAX << OFFSET_SUBJECT_ID);
+
+    return out;
+}
+
+CanardFilter canardMakeFilterForService(const CanardPortID service_id, const CanardNodeID local_node_id)
+{
+    CanardFilter out = {0};
+
+    out.extended_can_id = FLAG_SERVICE_NOT_MESSAGE | (((uint32_t) service_id) << OFFSET_SERVICE_ID) |
+                          (((uint32_t) local_node_id) << OFFSET_DST_NODE_ID);
+    out.extended_mask = FLAG_SERVICE_NOT_MESSAGE | FLAG_RESERVED_23 | (CANARD_SERVICE_ID_MAX << OFFSET_SERVICE_ID) |
+                        (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID);
+
+    return out;
+}
+
+CanardFilter canardMakeFilterForServices(const CanardNodeID local_node_id)
+{
+    CanardFilter out = {0};
+
+    out.extended_can_id = FLAG_SERVICE_NOT_MESSAGE | (((uint32_t) local_node_id) << OFFSET_DST_NODE_ID);
+    out.extended_mask   = FLAG_SERVICE_NOT_MESSAGE | FLAG_RESERVED_23 | (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID);
+
+    return out;
+}
+
+CanardFilter canardConsolidateFilters(const CanardFilter* a, const CanardFilter* b)
+{
+    CanardFilter out = {0};
+
+    out.extended_mask   = a->extended_mask & b->extended_mask & ~(a->extended_can_id ^ b->extended_can_id);
+    out.extended_can_id = a->extended_can_id & out.extended_mask;
+
+    return out;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,6 +83,6 @@ gen_test_matrix(test_private
         "-Wno-missing-declarations")
 
 gen_test_matrix(test_public
-        "test_public_tx.cpp;test_public_rx.cpp;test_public_roundtrip.cpp;test_self.cpp"
+        "test_public_tx.cpp;test_public_rx.cpp;test_public_roundtrip.cpp;test_self.cpp;test_public_filters.cpp"
         ""
         "-Wmissing-declarations")

--- a/tests/test_public_filters.cpp
+++ b/tests/test_public_filters.cpp
@@ -1,0 +1,66 @@
+// This software is distributed under the terms of the MIT License.
+// Copyright (c) 2016-2021 UAVCAN Development Team.
+
+#include "exposed.hpp"
+#include "helpers.hpp"
+#include "catch.hpp"
+
+constexpr uint32_t OFFSET_PRIORITY    = 26U;
+constexpr uint32_t OFFSET_SUBJECT_ID  = 8U;
+constexpr uint32_t OFFSET_SERVICE_ID  = 14U;
+constexpr uint32_t OFFSET_DST_NODE_ID = 7U;
+
+constexpr uint32_t FLAG_SERVICE_NOT_MESSAGE  = (UINT32_C(1) << 25U);
+constexpr uint32_t FLAG_ANONYMOUS_MESSAGE    = (UINT32_C(1) << 24U);
+constexpr uint32_t FLAG_REQUEST_NOT_RESPONSE = (UINT32_C(1) << 24U);
+constexpr uint32_t FLAG_RESERVED_23          = (UINT32_C(1) << 23U);
+constexpr uint32_t FLAG_RESERVED_07          = (UINT32_C(1) << 7U);
+
+TEST_CASE("FilterSubject")
+{
+    const uint16_t heartbeat_subject_id = 7509;
+    CanardFilter   heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
+    REQUIRE((heartbeat_config.extended_can_id & (uint32_t) (heartbeat_subject_id << OFFSET_SUBJECT_ID)) != 0);
+    REQUIRE((heartbeat_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
+    REQUIRE((heartbeat_config.extended_mask & FLAG_RESERVED_07) != 0);
+    REQUIRE((heartbeat_config.extended_mask & (CANARD_SUBJECT_ID_MAX << OFFSET_SUBJECT_ID)) != 0);
+}
+
+TEST_CASE("FilterService")
+{
+    const uint16_t access_service_id = 7509;
+    const uint16_t node_id           = 42;
+    CanardFilter   access_config     = canardMakeFilterForService(access_service_id, node_id);
+    REQUIRE((access_config.extended_can_id & (uint32_t) (access_service_id << OFFSET_SERVICE_ID)) != 0);
+    REQUIRE((access_config.extended_can_id & (uint32_t) (node_id << OFFSET_DST_NODE_ID)) != 0);
+    REQUIRE((access_config.extended_can_id & FLAG_SERVICE_NOT_MESSAGE) != 0);
+    REQUIRE((access_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
+    REQUIRE((access_config.extended_mask & FLAG_RESERVED_23) != 0);
+    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_SERVICE_ID_MAX << OFFSET_SERVICE_ID)) != 0);
+    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
+}
+
+TEST_CASE("FilterServices")
+{
+    const uint8_t node_id       = 42;
+    CanardFilter  access_config = canardMakeFilterForServices(node_id);
+    REQUIRE((access_config.extended_can_id & (uint32_t) (node_id << OFFSET_DST_NODE_ID)) != 0);
+    REQUIRE((access_config.extended_can_id & FLAG_SERVICE_NOT_MESSAGE) != 0);
+    REQUIRE((access_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
+    REQUIRE((access_config.extended_mask & FLAG_RESERVED_23) != 0);
+    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
+}
+
+TEST_CASE("Consolidate")
+{
+    const uint16_t heartbeat_subject_id = 7509;
+    CanardFilter   heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
+
+    const uint16_t access_service_id = 7509;
+    const uint8_t  node_id           = 42;
+    CanardFilter   access_config     = canardMakeFilterForService(access_service_id, node_id);
+
+    CanardFilter combined = canardConsolidateFilters(&heartbeat_config, &access_config);
+    REQUIRE((combined.extended_mask | heartbeat_config.extended_mask) == heartbeat_config.extended_mask);
+    REQUIRE((combined.extended_mask | access_config.extended_mask) == access_config.extended_mask);
+}

--- a/tests/test_public_filters.cpp
+++ b/tests/test_public_filters.cpp
@@ -5,22 +5,25 @@
 #include "helpers.hpp"
 #include "catch.hpp"
 
-constexpr uint32_t OFFSET_PRIORITY    = 26U;
-constexpr uint32_t OFFSET_SUBJECT_ID  = 8U;
-constexpr uint32_t OFFSET_SERVICE_ID  = 14U;
-constexpr uint32_t OFFSET_DST_NODE_ID = 7U;
+namespace
+{
+constexpr std::uint32_t OFFSET_PRIORITY    = 26U;
+constexpr std::uint32_t OFFSET_SUBJECT_ID  = 8U;
+constexpr std::uint32_t OFFSET_SERVICE_ID  = 14U;
+constexpr std::uint32_t OFFSET_DST_NODE_ID = 7U;
 
-constexpr uint32_t FLAG_SERVICE_NOT_MESSAGE  = (UINT32_C(1) << 25U);
-constexpr uint32_t FLAG_ANONYMOUS_MESSAGE    = (UINT32_C(1) << 24U);
-constexpr uint32_t FLAG_REQUEST_NOT_RESPONSE = (UINT32_C(1) << 24U);
-constexpr uint32_t FLAG_RESERVED_23          = (UINT32_C(1) << 23U);
-constexpr uint32_t FLAG_RESERVED_07          = (UINT32_C(1) << 7U);
+constexpr std::uint32_t FLAG_SERVICE_NOT_MESSAGE  = std::uint32_t(1) << 25U;
+constexpr std::uint32_t FLAG_ANONYMOUS_MESSAGE    = std::uint32_t(1) << 24U;
+constexpr std::uint32_t FLAG_REQUEST_NOT_RESPONSE = std::uint32_t(1) << 24U;
+constexpr std::uint32_t FLAG_RESERVED_23          = std::uint32_t(1) << 23U;
+constexpr std::uint32_t FLAG_RESERVED_07          = std::uint32_t(1) << 7U;
 
 TEST_CASE("FilterSubject")
 {
-    const uint16_t heartbeat_subject_id = 7509;
-    CanardFilter   heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
-    REQUIRE((heartbeat_config.extended_can_id & (uint32_t) (heartbeat_subject_id << OFFSET_SUBJECT_ID)) != 0);
+    const std::uint16_t heartbeat_subject_id = 7509;
+    CanardFilter        heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
+    REQUIRE((heartbeat_config.extended_can_id &
+             static_cast<std::uint32_t>(heartbeat_subject_id << OFFSET_SUBJECT_ID)) != 0);
     REQUIRE((heartbeat_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
     REQUIRE((heartbeat_config.extended_mask & FLAG_RESERVED_07) != 0);
     REQUIRE((heartbeat_config.extended_mask & (CANARD_SUBJECT_ID_MAX << OFFSET_SUBJECT_ID)) != 0);
@@ -28,39 +31,41 @@ TEST_CASE("FilterSubject")
 
 TEST_CASE("FilterService")
 {
-    const uint16_t access_service_id = 7509;
-    const uint16_t node_id           = 42;
-    CanardFilter   access_config     = canardMakeFilterForService(access_service_id, node_id);
-    REQUIRE((access_config.extended_can_id & (uint32_t) (access_service_id << OFFSET_SERVICE_ID)) != 0);
-    REQUIRE((access_config.extended_can_id & (uint32_t) (node_id << OFFSET_DST_NODE_ID)) != 0);
+    const std::uint16_t access_service_id = 7509;
+    const std::uint16_t node_id           = 42;
+    CanardFilter        access_config     = canardMakeFilterForService(access_service_id, node_id);
+    REQUIRE((access_config.extended_can_id & static_cast<std::uint32_t>(access_service_id << OFFSET_SERVICE_ID)) != 0);
+    REQUIRE((access_config.extended_can_id & static_cast<std::uint32_t>(node_id << OFFSET_DST_NODE_ID)) != 0);
     REQUIRE((access_config.extended_can_id & FLAG_SERVICE_NOT_MESSAGE) != 0);
     REQUIRE((access_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
     REQUIRE((access_config.extended_mask & FLAG_RESERVED_23) != 0);
-    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_SERVICE_ID_MAX << OFFSET_SERVICE_ID)) != 0);
-    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
+    REQUIRE((access_config.extended_mask & static_cast<std::uint32_t>(CANARD_SERVICE_ID_MAX << OFFSET_SERVICE_ID)) !=
+            0);
+    REQUIRE((access_config.extended_mask & static_cast<std::uint32_t>(CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
 }
 
 TEST_CASE("FilterServices")
 {
-    const uint8_t node_id       = 42;
-    CanardFilter  access_config = canardMakeFilterForServices(node_id);
-    REQUIRE((access_config.extended_can_id & (uint32_t) (node_id << OFFSET_DST_NODE_ID)) != 0);
+    const std::uint8_t node_id       = 42;
+    CanardFilter       access_config = canardMakeFilterForServices(node_id);
+    REQUIRE((access_config.extended_can_id & static_cast<std::uint32_t>(node_id << OFFSET_DST_NODE_ID)) != 0);
     REQUIRE((access_config.extended_can_id & FLAG_SERVICE_NOT_MESSAGE) != 0);
     REQUIRE((access_config.extended_mask & FLAG_SERVICE_NOT_MESSAGE) != 0);
     REQUIRE((access_config.extended_mask & FLAG_RESERVED_23) != 0);
-    REQUIRE((access_config.extended_mask & (uint32_t) (CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
+    REQUIRE((access_config.extended_mask & static_cast<std::uint32_t>(CANARD_NODE_ID_MAX << OFFSET_DST_NODE_ID)) != 0);
 }
 
 TEST_CASE("Consolidate")
 {
-    const uint16_t heartbeat_subject_id = 7509;
-    CanardFilter   heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
+    const std::uint16_t heartbeat_subject_id = 7509;
+    CanardFilter        heartbeat_config     = canardMakeFilterForSubject(heartbeat_subject_id);
 
-    const uint16_t access_service_id = 7509;
-    const uint8_t  node_id           = 42;
-    CanardFilter   access_config     = canardMakeFilterForService(access_service_id, node_id);
+    const std::uint16_t access_service_id = 7509;
+    const std::uint8_t  node_id           = 42;
+    CanardFilter        access_config     = canardMakeFilterForService(access_service_id, node_id);
 
     CanardFilter combined = canardConsolidateFilters(&heartbeat_config, &access_config);
     REQUIRE((combined.extended_mask | heartbeat_config.extended_mask) == heartbeat_config.extended_mask);
     REQUIRE((combined.extended_mask | access_config.extended_mask) == access_config.extended_mask);
 }
+}  // namespace


### PR DESCRIPTION
Briefly tested all 3 functions on a test project with yakut. Appears to work, and it's super simple.

@pavel-kirienko Does it make more sense from an API perspective to use the CanardInstance itself as an argument for the service generator and pull the local node id from that?

Closes #169 