### PR TITLE
clang-tidy: make static code check happy.

### DIFF
--- a/libcanard/.clang-tidy
+++ b/libcanard/.clang-tidy
@@ -19,7 +19,6 @@ Checks: >-
 CheckOptions:
   - key:   readability-function-cognitive-complexity.Threshold
     value: '99'
-WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle: file


### PR DESCRIPTION
removed the WarningsAsErrors flag to fix #178 